### PR TITLE
rename extract-regions to extract-pages, add extract-regions

### DIFF
--- a/ocrd_segment/cli.py
+++ b/ocrd_segment/cli.py
@@ -3,6 +3,7 @@ import click
 from ocrd.decorators import ocrd_cli_options, ocrd_cli_wrap_processor
 from ocrd_segment.repair import RepairSegmentation
 from ocrd_segment.evaluate import EvaluateSegmentation
+from ocrd_segment.extract_pages import ExtractPages
 from ocrd_segment.extract_regions import ExtractRegions
 from ocrd_segment.extract_lines import ExtractLines
 
@@ -15,6 +16,11 @@ def ocrd_segment_repair(*args, **kwargs):
 @ocrd_cli_options
 def ocrd_segment_evaluate(*args, **kwargs):
     return ocrd_cli_wrap_processor(EvaluateSegmentation, *args, **kwargs)
+
+@click.command()
+@ocrd_cli_options
+def ocrd_segment_extract_pages(*args, **kwargs):
+    return ocrd_cli_wrap_processor(ExtractPages, *args, **kwargs)
 
 @click.command()
 @ocrd_cli_options

--- a/ocrd_segment/extract_pages.py
+++ b/ocrd_segment/extract_pages.py
@@ -1,0 +1,146 @@
+from __future__ import absolute_import
+
+import json
+from PIL import Image, ImageDraw
+
+from ocrd_utils import (
+    getLogger, concat_padded,
+    coordinates_of_segment
+)
+from ocrd_models.ocrd_page import (
+    LabelsType, LabelType,
+    MetadataItemType
+)
+from ocrd_modelfactory import page_from_file
+from ocrd import Processor
+
+from .config import OCRD_TOOL
+
+TOOL = 'ocrd-segment-extract-pages'
+LOG = getLogger('processor.ExtractPages')
+# region classes and their colours in debug images:
+CLASSES = {'border': (255, 255, 255),
+           'text': (200, 0, 0),
+           'table': (0, 100, 20),
+           'chart': (0, 120, 0),
+           'chem': (0, 140, 0),
+           'graphic': (0, 0, 200),
+           'image': (0, 20, 180),
+           'linedrawing': (20, 0, 180),
+           'maths': (20, 120, 0),
+           'music': (20, 120, 40),
+           'noise': (50, 50, 50),
+           'separator': (0, 0, 100),
+           'unknown': (0, 0, 0)
+}
+
+class ExtractPages(Processor):
+
+    def __init__(self, *args, **kwargs):
+        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
+        kwargs['version'] = OCRD_TOOL['version']
+        super(ExtractPages, self).__init__(*args, **kwargs)
+
+    def process(self):
+        """Extract page images and region descriptions (type and coordinates) from the workspace.
+        
+        Open and deserialize PAGE input files and their respective images,
+        then iterate over the element hierarchy down to the region level.
+        
+        Get all regions with their types (region element class), sub-types (@type)
+        and coordinates relative to the page (which depending on the workflow could
+        already be cropped, deskewed, dewarped, binarized etc). Extract the image of
+        the page, both in binarized and non-binarized form. In addition, create a new
+        image which color-codes all regions. Create a JSON file with region types and
+        coordinates.
+        
+        Write all files in the directory of the output file group, named like so:
+        * ID + '.png': raw image
+        * ID + '.bin.png': binarized image
+        * ID + '.dbg.png': debug image
+        * ID + '.json': region coordinates
+        
+        (This is intended for training and evaluation of region segmentation models.)
+        """
+        # pylint: disable=attribute-defined-outside-init
+        for n, input_file in enumerate(self.input_files):
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
+            page_id = input_file.pageId or input_file.ID
+            LOG.info("INPUT FILE %i / %s", n, page_id)
+            pcgts = page_from_file(self.workspace.download_file(input_file))
+            page = pcgts.get_Page()
+            ptype = page.get_type()
+            metadata = pcgts.get_Metadata() # ensured by from_file()
+            metadata.add_MetadataItem(
+                MetadataItemType(type_="processingStep",
+                                 name=self.ocrd_tool['steps'][0],
+                                 value=TOOL,
+                                 Labels=[LabelsType(
+                                     externalModel="ocrd-tool",
+                                     externalId="parameters",
+                                     Label=[LabelType(type_=name,
+                                                      value=self.parameter[name])
+                                            for name in self.parameter.keys()])]))
+            page_image, page_coords, page_image_info = self.workspace.image_from_page(
+                page, page_id,
+                feature_filter='binarized',
+                transparency=self.parameter['transparency'])
+            if page_image_info.resolution != 1:
+                dpi = page_image_info.resolution
+                if page_image_info.resolutionUnit == 'cm':
+                    dpi = round(dpi * 2.54)
+            else:
+                dpi = None
+            file_path = self.workspace.save_image_file(page_image,
+                                                       file_id,
+                                                       self.output_file_grp,
+                                                       page_id=page_id)
+            page_image_bin, _, _ = self.workspace.image_from_page(
+                page, page_id,
+                feature_selector='binarized',
+                transparency=self.parameter['transparency'])
+            self.workspace.save_image_file(page_image_bin,
+                                           file_id + '.bin',
+                                           self.output_file_grp,
+                                           page_id=page_id)
+            page_image_dbg = Image.new(mode='RGB', size=page_image.size, color=0)
+            regions = { 'text': page.get_TextRegion(),
+                        'table': page.get_TableRegion(),
+                        'chart': page.get_ChartRegion(),
+                        'chem': page.get_ChemRegion(),
+                        'graphic': page.get_GraphicRegion(),
+                        'image': page.get_ImageRegion(),
+                        'linedrawing': page.get_LineDrawingRegion(),
+                        'maths': page.get_MathsRegion(),
+                        'music': page.get_MusicRegion(),
+                        'noise': page.get_NoiseRegion(),
+                        'separator': page.get_SeparatorRegion(),
+                        'unknown': page.get_UnknownRegion()
+            }
+            description = { 'angle': page.get_orientation() }
+            for rtype, rlist in regions.items():
+                for region in rlist:
+                    polygon = coordinates_of_segment(
+                        region, page_image, page_coords).tolist()
+                    description.setdefault('regions', []).append(
+                        { 'type': rtype,
+                          'subtype': region.get_type() if rtype in ['text', 'chart', 'graphic'] else None,
+                          'coords': polygon,
+                          'features': page_coords['features'],
+                          'DPI': dpi,
+                          'region.ID': region.id,
+                          'page.ID': page_id,
+                          'page.type': ptype,
+                          'file_grp': self.input_file_grp,
+                          'METS.UID': self.workspace.mets.unique_identifier
+                        })
+                    ImageDraw.Draw(page_image_dbg).polygon(list(map(tuple, polygon)),
+                                                               fill=CLASSES[rtype])
+                    ImageDraw.Draw(page_image_dbg).line(list(map(tuple, polygon + [polygon[0]])), 
+                                                            fill=CLASSES['border'], width=3)
+            self.workspace.save_image_file(page_image_dbg,
+                                           file_id + '.dbg',
+                                           self.output_file_grp,
+                                           page_id=page_id)
+            file_path = file_path.replace('.png', '.json')
+            json.dump(description, open(file_path, 'w'))

--- a/ocrd_segment/extract_regions.py
+++ b/ocrd_segment/extract_regions.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
 
+import os.path
 import json
-from PIL import Image, ImageDraw
 
 from ocrd_utils import (
     getLogger, concat_padded,
-    coordinates_of_segment
+    coordinates_of_segment,
+    polygon_from_points
 )
 from ocrd_models.ocrd_page import (
     LabelsType, LabelType,
@@ -18,21 +19,6 @@ from .config import OCRD_TOOL
 
 TOOL = 'ocrd-segment-extract-regions'
 LOG = getLogger('processor.ExtractRegions')
-# region classes and their colours in debug images:
-CLASSES = {'border': (255, 255, 255),
-           'text': (200, 0, 0),
-           'table': (0, 100, 20),
-           'chart': (0, 120, 0),
-           'chem': (0, 140, 0),
-           'graphic': (0, 0, 200),
-           'image': (0, 20, 180),
-           'linedrawing': (20, 0, 180),
-           'maths': (20, 120, 0),
-           'music': (20, 120, 40),
-           'noise': (50, 50, 50),
-           'separator': (0, 0, 100),
-           'unknown': (0, 0, 0)
-}
 
 class ExtractRegions(Processor):
 
@@ -42,34 +28,49 @@ class ExtractRegions(Processor):
         super(ExtractRegions, self).__init__(*args, **kwargs)
 
     def process(self):
-        """Extract page images and region descriptions (type and coordinates) from the workspace.
+        """Extract region images from the workspace.
         
         Open and deserialize PAGE input files and their respective images,
         then iterate over the element hierarchy down to the region level.
         
-        Get all regions with their types (region element class), sub-types (@type)
-        and coordinates relative to the page (which depending on the workflow could
-        already be cropped, deskewed, dewarped, binarized etc). Extract the image of
-        the page, both in binarized and non-binarized form. In addition, create a new
-        image which color-codes all regions. Create a JSON file with region types and
-        coordinates.
+        Extract an image for each region (which depending on the workflow
+        can already be deskewed, dewarped, binarized etc.), cropped to its
+        minimal bounding box, and masked by the coordinate polygon outline.
+        If ``transparency`` is true, then also add an alpha channel which is
+        fully transparent outside of the mask.
+        
+        Create a JSON file with:
+        * the IDs of the region and its parents,
+        * the region's coordinates relative to the region image,
+        * the region's absolute coordinates,
+        * the (text) region's text content (if any),
+        * the (text) region's TextStyle (if any),
+        * the (text) region's @production (if any),
+        * the (text) region's @readingDirection (if any),
+        * the (text) region's @textLineOrder (if any),
+        * the (text) region's @primaryScript (if any),
+        * the (text) region's @primaryLanguage (if any),
+        * the region's AlternativeImage/@comments (features),
+        * the region's element class,
+        * the region's @type,
+        * the page's @type,
+        * the page's DPI value.
         
         Write all files in the directory of the output file group, named like so:
-        * ID + '.png': raw image
-        * ID + '.bin.png': binarized image
-        * ID + '.dbg.png': debug image
-        * ID + '.json': region coordinates
-        
-        (This is intended for training and evaluation of region segmentation models.)
+        * ID + '.raw.png': region image (if the workflow provides raw images)
+        * ID + '.bin.png': region image (if the workflow provides binarized images)
+        * ID + '.nrm.png': region image (if the workflow provides grayscale-normalized images)
+        * ID + '.json': region metadata.
         """
         # pylint: disable=attribute-defined-outside-init
         for n, input_file in enumerate(self.input_files):
             file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
+            if file_id == input_file.ID:
+                file_id = concat_padded(self.output_file_grp, n)
             page_id = input_file.pageId or input_file.ID
             LOG.info("INPUT FILE %i / %s", n, page_id)
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page = pcgts.get_Page()
-            ptype = page.get_type()
             metadata = pcgts.get_Metadata() # ensured by from_file()
             metadata.add_MetadataItem(
                 MetadataItemType(type_="processingStep",
@@ -83,7 +84,6 @@ class ExtractRegions(Processor):
                                             for name in self.parameter.keys()])]))
             page_image, page_coords, page_image_info = self.workspace.image_from_page(
                 page, page_id,
-                feature_filter='binarized',
                 transparency=self.parameter['transparency'])
             if page_image_info.resolution != 1:
                 dpi = page_image_info.resolution
@@ -91,20 +91,10 @@ class ExtractRegions(Processor):
                     dpi = round(dpi * 2.54)
             else:
                 dpi = None
-            file_path = self.workspace.save_image_file(page_image,
-                                                       file_id,
-                                                       self.output_file_grp,
-                                                       page_id=page_id)
-            page_image_bin, _, _ = self.workspace.image_from_page(
-                page, page_id,
-                feature_selector='binarized',
-                transparency=self.parameter['transparency'])
-            self.workspace.save_image_file(page_image_bin,
-                                           file_id + '.bin',
-                                           self.output_file_grp,
-                                           page_id=page_id)
-            page_image_dbg = Image.new(mode='RGB', size=page_image.size, color=0)
-            regions = { 'text': page.get_TextRegion(),
+            ptype = page.get_type()
+
+            regions = { 'advert': page.get_AdvertRegion(),
+                        'text': page.get_TextRegion(),
                         'table': page.get_TableRegion(),
                         'chart': page.get_ChartRegion(),
                         'chem': page.get_ChemRegion(),
@@ -117,30 +107,73 @@ class ExtractRegions(Processor):
                         'separator': page.get_SeparatorRegion(),
                         'unknown': page.get_UnknownRegion()
             }
-            description = { 'angle': page.get_orientation() }
             for rtype, rlist in regions.items():
                 for region in rlist:
-                    polygon = coordinates_of_segment(
-                        region, page_image, page_coords).tolist()
-                    description.setdefault('regions', []).append(
-                        { 'type': rtype,
-                          'subtype': region.get_type() if rtype in ['text', 'chart', 'graphic'] else None,
-                          'coords': polygon,
-                          'features': page_coords['features'],
-                          'DPI': dpi,
-                          'region.ID': region.id,
-                          'page.ID': page_id,
-                          'page.type': ptype,
-                          'file_grp': self.input_file_grp,
-                          'METS.UID': self.workspace.mets.unique_identifier
-                        })
-                    ImageDraw.Draw(page_image_dbg).polygon(list(map(tuple, polygon)),
-                                                               fill=CLASSES[rtype])
-                    ImageDraw.Draw(page_image_dbg).line(list(map(tuple, polygon + [polygon[0]])), 
-                                                            fill=CLASSES['border'], width=3)
-            self.workspace.save_image_file(page_image_dbg,
-                                           file_id + '.dbg',
-                                           self.output_file_grp,
-                                           page_id=page_id)
-            file_path = file_path.replace('.png', '.json')
-            json.dump(description, open(file_path, 'w'))
+                    description = { 'region.ID': region.id, 'region.type': rtype }
+                    region_image, region_coords = self.workspace.image_from_segment(
+                        region, page_image, page_coords,
+                        transparency=self.parameter['transparency'])
+                    description['subtype'] = region.get_type() if rtype in ['text', 'chart', 'graphic'] else None
+                    description['coords_rel'] = coordinates_of_segment(
+                        region, region_image, region_coords).tolist()
+                    description['coords_abs'] = polygon_from_points(region.get_Coords().points)
+                    if rtype == 'text':
+                        rtext = region.get_TextEquiv()
+                        if rtext:
+                            description['region.text'] = rtext[0].Unicode
+                        else:
+                            description['region.text'] = ''
+                        rstyle = region.get_TextStyle() or page.get_TextStyle()
+                        if rstyle:
+                            description['region.style'] = {
+                                'fontFamily': rstyle.fontFamily,
+                                'fontSize': rstyle.fontSize,
+                                'xHeight': rstyle.xHeight,
+                                'kerning': rstyle.kerning,
+                                'serif': rstyle.serif,
+                                'monospace': rstyle.monospace,
+                                'bold': rstyle.bold,
+                                'italic': rstyle.italic,
+                                'smallCaps': rstyle.smallCaps,
+                                'letterSpaced': rstyle.letterSpaced,
+                                'strikethrough': rstyle.strikethrough,
+                                'underlined': rstyle.underlined,
+                                'underlineStyle': rstyle.underlineStyle,
+                                'subscript': rstyle.subscript,
+                                'superscript': rstyle.superscript
+                            }
+                        description['production'] = region.get_production()
+                        description['readingDirection'] = (
+                            region.get_readingDirection() or
+                            page.get_readingDirection())
+                        description['textLineOrder'] = (
+                            region.get_textLineOrder() or
+                            page.get_textLineOrder())
+                        description['primaryScript'] = (
+                            region.get_primaryScript() or
+                            page.get_primaryScript())
+                        description['primaryLanguage'] = (
+                            region.get_primaryLanguage() or
+                            page.get_primaryLanguage())
+                    description['features'] = region_coords['features']
+                    description['DPI']= dpi
+                    description['page.ID'] = page_id
+                    description['page.type'] = ptype
+                    description['file_grp'] = self.input_file_grp
+                    description['METS.UID'] = self.workspace.mets.unique_identifier
+                    if 'binarized' in region_coords['features']:
+                        extension = '.bin'
+                    elif 'grayscale_normalized' in region_coords['features']:
+                        extension = '.nrm'
+                    else:
+                        extension = '.raw'
+                    
+                    file_path = self.workspace.save_image_file(
+                        region_image,
+                        file_id + '_' + region.id + extension,
+                        self.output_file_grp,
+                        page_id=page_id,
+                        format='PNG')
+                    file_path = file_path.replace(extension + '.png', '.json')
+                    json.dump(description, open(file_path, 'w'))
+

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 Installs:
 
     - ocrd-segment-repair
+    - ocrd-segment-extract-pages
     - ocrd-segment-extract-regions
     - ocrd-segment-extract-lines
     - ocrd-segment-evaluate
@@ -28,6 +29,7 @@ setup(
     entry_points={
         'console_scripts': [
             'ocrd-segment-repair=ocrd_segment.cli:ocrd_segment_repair',
+            'ocrd-segment-extract-pages=ocrd_segment.cli:ocrd_segment_extract_pages',
             'ocrd-segment-extract-regions=ocrd_segment.cli:ocrd_segment_extract_regions',
             'ocrd-segment-extract-lines=ocrd_segment.cli:ocrd_segment_extract_lines',
             'ocrd-segment-evaluate=ocrd_segment.cli:ocrd_segment_evaluate',


### PR DESCRIPTION
The existing `extract-regions` actually gave us page images, we missed an actual region image extractor.