### PR TITLE
repair/plausibilize: merge regions almost within others

### DIFF
--- a/ocrd_segment/ocrd-tool.json
+++ b/ocrd_segment/ocrd-tool.json
@@ -23,7 +23,13 @@
         "plausibilize": {
           "type": "boolean",
           "default": false,
-          "description": "Modify the region segmentation to make it (more) plausible"
+          "description": "Remove redundant (almost equal or almost contained) regions, and merge overlapping regions"
+        },
+        "plausibilize_merge_min_overlap": {
+          "type": "number",
+          "format": "float",
+          "default": 0.90,
+          "description": "When merging a region almost contained in another, require at least this ratio of area is shared with the other"
         }
       }
     },

--- a/ocrd_segment/repair.py
+++ b/ocrd_segment/repair.py
@@ -128,9 +128,13 @@ class RepairSegmentation(Processor):
                         mark_for_deletion.append(region1.id)
                     elif poly1.overlaps(poly2):
                         inter_poly = poly1.intersection(poly2)
+                        union_poly = poly1.union(poly2)
                         LOG.debug('Page "%s" region "%s" overlaps "%s" by %f/%f',
                                   page_id, region1.id, region2.id, inter_poly.area/poly1.area, inter_poly.area/poly2.area)
-                        if inter_poly.area / poly2.area > self.parameter['plausibilize_merge_min_overlap']:
+                        if union_poly.convex_hull.area >= poly1.area + poly2.area:
+                            # skip this pair -- combined polygon encloses previously free segments
+                            pass
+                        elif inter_poly.area / poly2.area > self.parameter['plausibilize_merge_min_overlap']:
                             LOG.warning('Page "%s" region "%s" is almost within "%s" %s',
                                         page_id, region2.id, region1.id,
                                         '(merging)' if plausibilize else '')


### PR DESCRIPTION
- fix removing regions with plausibilize: also delete
  if not appearing within reading order
- add first case of merging in addition to removing:
  if a region overlaps another and is almost within it
  (with the area of the intersection above a given
   percentage of the total), then merge that region
  into the superregion
  * ensure correct ordering so the superregion is
    guaranteed not to have been removed/merged itself yet
  * set the coordinate polygon as the union of both
  * warn of any differences in attributes/subelements