### PR TITLE
Extract format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ pip install .
 
 ## Usage
 
-  - extracting page images (including results from preprocessing like cropping, deskewing or binarization) along with region polygon coordinates and metadata:
+  - extracting page images (including results from preprocessing like cropping/masking, deskewing, dewarping or binarization) along with region polygon coordinates and metadata:
+    - [ocrd-segment-extract-pages](ocrd_segment/extract_pages.py)
+  - extracting region images (including results from preprocessing like cropping/masking, deskewing, dewarping or binarization) along with region polygon coordinates and metadata:
     - [ocrd-segment-extract-regions](ocrd_segment/extract_regions.py)
-  - extracting line images (including results from preprocessing like cropping, deskewing, dewarping or binarization) along with line polygon coordinates and metadata:
+  - extracting line images (including results from preprocessing like cropping/masking, deskewing, dewarping or binarization) along with line polygon coordinates and metadata:
     - [ocrd-segment-extract-lines](ocrd_segment/extract_lines.py)
   - comparing different layout segmentations (input file groups N = 2, compute the distance between two segmentations, e.g. automatic vs. manual):
     - [ocrd-segment-evaluate](ocrd_segment/evaluate.py) :construction: (very early stage)

--- a/ocrd_segment/extract_lines.py
+++ b/ocrd_segment/extract_lines.py
@@ -6,7 +6,8 @@ import json
 from ocrd_utils import (
     getLogger, concat_padded,
     coordinates_of_segment,
-    polygon_from_points
+    polygon_from_points,
+    MIME_TO_EXT
 )
 from ocrd_models.ocrd_page import (
     LabelsType, LabelType,
@@ -182,8 +183,8 @@ class ExtractLines(Processor):
                         file_id + '_' + region.id + '_' + line.id + extension,
                         self.output_file_grp,
                         page_id=page_id,
-                        format=self.parameter['format'])
-                    file_path = file_path.replace(extension + '.' + self.parameter['format'].lower(), '.json')
+                        mimetype=self.parameter['mimetype'])
+                    file_path = file_path.replace(extension + MIME_TO_EXT[self.parameter['mimetype']], '.json')
                     json.dump(description, open(file_path, 'w'))
                     file_path = file_path.replace('.json', '.gt.txt')
                     with open(file_path, 'wb') as f:

--- a/ocrd_segment/extract_lines.py
+++ b/ocrd_segment/extract_lines.py
@@ -182,8 +182,8 @@ class ExtractLines(Processor):
                         file_id + '_' + region.id + '_' + line.id + extension,
                         self.output_file_grp,
                         page_id=page_id,
-                        format='PNG')
-                    file_path = file_path.replace(extension + '.png', '.json')
+                        format=self.parameter['format'])
+                    file_path = file_path.replace(extension + '.' + self.parameter['format'].lower(), '.json')
                     json.dump(description, open(file_path, 'w'))
                     file_path = file_path.replace('.json', '.gt.txt')
                     with open(file_path, 'wb') as f:

--- a/ocrd_segment/extract_pages.py
+++ b/ocrd_segment/extract_pages.py
@@ -5,7 +5,8 @@ from PIL import Image, ImageDraw
 
 from ocrd_utils import (
     getLogger, concat_padded,
-    coordinates_of_segment
+    coordinates_of_segment,
+    MIME_TO_EXT
 )
 from ocrd_models.ocrd_page import (
     LabelsType, LabelType,
@@ -94,7 +95,8 @@ class ExtractPages(Processor):
             file_path = self.workspace.save_image_file(page_image,
                                                        file_id,
                                                        self.output_file_grp,
-                                                       page_id=page_id)
+                                                       page_id=page_id,
+                                                       mimetype=self.parameter['mimetype'])
             page_image_bin, _, _ = self.workspace.image_from_page(
                 page, page_id,
                 feature_selector='binarized',
@@ -142,6 +144,6 @@ class ExtractPages(Processor):
                                            file_id + '.dbg',
                                            self.output_file_grp,
                                            page_id=page_id,
-                                           format=self.parameter['format'])
-            file_path = file_path.replace('.' + self.parameter['format'].lower(), '.json')
+                                           mimetype=self.parameter['mimetype'])
+            file_path = file_path.replace(MIME_TO_EXT[self.parameter['mimetype']], '.json')
             json.dump(description, open(file_path, 'w'))

--- a/ocrd_segment/extract_pages.py
+++ b/ocrd_segment/extract_pages.py
@@ -141,6 +141,7 @@ class ExtractPages(Processor):
             self.workspace.save_image_file(page_image_dbg,
                                            file_id + '.dbg',
                                            self.output_file_grp,
-                                           page_id=page_id)
-            file_path = file_path.replace('.png', '.json')
+                                           page_id=page_id,
+                                           format=self.parameter['format'])
+            file_path = file_path.replace('.' + self.parameter['format'].lower(), '.json')
             json.dump(description, open(file_path, 'w'))

--- a/ocrd_segment/extract_regions.py
+++ b/ocrd_segment/extract_regions.py
@@ -173,7 +173,7 @@ class ExtractRegions(Processor):
                         file_id + '_' + region.id + extension,
                         self.output_file_grp,
                         page_id=page_id,
-                        format='PNG')
-                    file_path = file_path.replace(extension + '.png', '.json')
+                        format=self.parameter['format'])
+                    file_path = file_path.replace(extension + '.' + self.parameter['format'].lower(), '.json')
                     json.dump(description, open(file_path, 'w'))
 

--- a/ocrd_segment/extract_regions.py
+++ b/ocrd_segment/extract_regions.py
@@ -6,7 +6,8 @@ import json
 from ocrd_utils import (
     getLogger, concat_padded,
     coordinates_of_segment,
-    polygon_from_points
+    polygon_from_points,
+    MIME_TO_EXT
 )
 from ocrd_models.ocrd_page import (
     LabelsType, LabelType,
@@ -173,7 +174,7 @@ class ExtractRegions(Processor):
                         file_id + '_' + region.id + extension,
                         self.output_file_grp,
                         page_id=page_id,
-                        format=self.parameter['format'])
-                    file_path = file_path.replace(extension + '.' + self.parameter['format'].lower(), '.json')
+                        mimetype=self.parameter['mimetype'])
+                    file_path = file_path.replace(extension + MIME_TO_EXT[self.parameter['mimetype']], '.json')
                     json.dump(description, open(file_path, 'w'))
 

--- a/ocrd_segment/ocrd-tool.json
+++ b/ocrd_segment/ocrd-tool.json
@@ -48,10 +48,10 @@
       ],
       "steps": ["layout/analysis"],
       "parameters": {
-        "format": {
+        "mimetype": {
           "type": "string",
-          "enum": ["BMP", "EPS", "GIF", "JPEG", "JP2", "MSP", "PCX", "PNG", "PPM", "TIFF"],
-          "default": "PNG",
+          "enum": ["image/bmp", "application/postscript", "image/gif", "image/jpeg", "image/jp2", "image/png", "image/x-portable-pixmap", "image/tiff"],
+          "default": "image/png",
           "description": "File format to save extracted images in."
         },
         "transparency": {
@@ -74,10 +74,10 @@
       ],
       "steps": ["layout/analysis"],
       "parameters": {
-        "format": {
+        "mimetype": {
           "type": "string",
-          "enum": ["BMP", "EPS", "GIF", "JPEG", "JP2", "MSP", "PCX", "PNG", "PPM", "TIFF"],
-          "default": "PNG",
+          "enum": ["image/bmp", "application/postscript", "image/gif", "image/jpeg", "image/jp2", "image/png", "image/x-portable-pixmap", "image/tiff"],
+          "default": "image/png",
           "description": "File format to save extracted images in."
         },
         "transparency": {
@@ -100,10 +100,10 @@
       ],
       "steps": ["layout/analysis"],
       "parameters": {
-        "format": {
+        "mimetype": {
           "type": "string",
-          "enum": ["BMP", "EPS", "GIF", "JPEG", "JP2", "MSP", "PCX", "PNG", "PPM", "TIFF"],
-          "default": "PNG",
+          "enum": ["image/bmp", "application/postscript", "image/gif", "image/jpeg", "image/jp2", "image/png", "image/x-portable-pixmap", "image/tiff"],
+          "default": "image/png",
           "description": "File format to save extracted images in."
         },
         "transparency": {

--- a/ocrd_segment/ocrd-tool.json
+++ b/ocrd_segment/ocrd-tool.json
@@ -48,6 +48,12 @@
       ],
       "steps": ["layout/analysis"],
       "parameters": {
+        "format": {
+          "type": "string",
+          "enum": ["BMP", "EPS", "GIF", "JPEG", "JP2", "MSP", "PCX", "PNG", "PPM", "TIFF"],
+          "default": "PNG",
+          "description": "File format to save extracted images in."
+        },
         "transparency": {
           "type": "boolean",
           "default": true,
@@ -68,6 +74,12 @@
       ],
       "steps": ["layout/analysis"],
       "parameters": {
+        "format": {
+          "type": "string",
+          "enum": ["BMP", "EPS", "GIF", "JPEG", "JP2", "MSP", "PCX", "PNG", "PPM", "TIFF"],
+          "default": "PNG",
+          "description": "File format to save extracted images in."
+        },
         "transparency": {
           "type": "boolean",
           "default": true,
@@ -88,6 +100,12 @@
       ],
       "steps": ["layout/analysis"],
       "parameters": {
+        "format": {
+          "type": "string",
+          "enum": ["BMP", "EPS", "GIF", "JPEG", "JP2", "MSP", "PCX", "PNG", "PPM", "TIFF"],
+          "default": "PNG",
+          "description": "File format to save extracted images in."
+        },
         "transparency": {
           "type": "boolean",
           "default": true,

--- a/ocrd_segment/ocrd-tool.json
+++ b/ocrd_segment/ocrd-tool.json
@@ -33,10 +33,32 @@
         }
       }
     },
+    "ocrd-segment-extract-pages": {
+      "executable": "ocrd-segment-extract-pages",
+      "categories": ["Image preprocessing"],
+      "description": "Extract page segmentation (border/skew) as image+JSON, including region coordinates/classes.",
+      "input_file_grp": [
+        "OCR-D-SEG-PAGE",
+        "OCR-D-GT-SEG-PAGE",
+        "OCR-D-SEG-BLOCK",
+        "OCR-D-GT-SEG-BLOCK"
+      ],
+      "output_file_grp": [
+        "OCR-D-IMG-CROP"
+      ],
+      "steps": ["layout/analysis"],
+      "parameters": {
+        "transparency": {
+          "type": "boolean",
+          "default": true,
+          "description": "Add alpha channels with segment masks to the images"
+        }
+      }
+    },
     "ocrd-segment-extract-regions": {
       "executable": "ocrd-segment-extract-regions",
       "categories": ["Image preprocessing"],
-      "description": "Extract region segmentation as image+JSON",
+      "description": "Extract region segmentation (polygon/skew) as image+JSON.",
       "input_file_grp": [
         "OCR-D-SEG-BLOCK",
         "OCR-D-GT-SEG-BLOCK"
@@ -56,7 +78,7 @@
     "ocrd-segment-extract-lines": {
       "executable": "ocrd-segment-extract-lines",
       "categories": ["Image preprocessing"],
-      "description": "Extract line segmentation as image+txt+JSON",
+      "description": "Extract line segmentation (polygon) as image+txt+JSON.",
       "input_file_grp": [
         "OCR-D-SEG-LINE",
         "OCR-D-GT-SEG-LINE"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-ocrd >= 2.0.2
+ocrd >= 2.4.0
 shapely
 scikit-image
+numpy


### PR DESCRIPTION
Fixes #20 

It would be more reliable if we managed MIME types and file extensions explicitly (instead of just `lower()` of `PIL.Image` format strings), but that would also require changes to `ocrd.workspace.Workspace.add_image_file()`...

