### PR TITLE
COCO and image mask segmentation converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ pip install .
     - [ocrd-segment-evaluate](ocrd_segment/evaluate.py) :construction: (very early stage)
   - repairing layout segmentations (input file groups N >= 1, based on heuristics implemented using Shapely):
     - [ocrd-segment-repair](ocrd_segment/repair.py) :construction: (much to be done)
+  - importing layout segmentations from other formats (mask images, MS-COCO JSON annotation):
+    - [ocrd-segment-from-masks](ocrd_segment/import_image_segmentation.py)
+    - [ocrd-segment-from-coco](ocrd_segment/import_coco_segmentation.py) :construction: (unpublished)
   - pattern-based segmentation (input file groups N=1, based on a PAGE template, e.g. from Aletheia, and some XSLT or Python to apply it to the input file group)
     - `ocrd-segment-via-template` :construction: (unpublished)
   - data-driven segmentation (input file groups N=1, based on a statistical model, e.g. Neural Network)  

--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ pip install .
 
 ## Usage
 
-  - extracting page images (including results from preprocessing like cropping/masking, deskewing, dewarping or binarization) along with region polygon coordinates and metadata:
+  - exporting page images (including results from preprocessing like cropping/masking, deskewing, dewarping or binarization) along with region polygon coordinates and metadata, also MS-COCO:
     - [ocrd-segment-extract-pages](ocrd_segment/extract_pages.py)
-  - extracting region images (including results from preprocessing like cropping/masking, deskewing, dewarping or binarization) along with region polygon coordinates and metadata:
+  - exporting region images (including results from preprocessing like cropping/masking, deskewing, dewarping or binarization) along with region polygon coordinates and metadata:
     - [ocrd-segment-extract-regions](ocrd_segment/extract_regions.py)
-  - extracting line images (including results from preprocessing like cropping/masking, deskewing, dewarping or binarization) along with line polygon coordinates and metadata:
+  - exporting line images (including results from preprocessing like cropping/masking, deskewing, dewarping or binarization) along with line polygon coordinates and metadata:
     - [ocrd-segment-extract-lines](ocrd_segment/extract_lines.py)
-  - comparing different layout segmentations (input file groups N = 2, compute the distance between two segmentations, e.g. automatic vs. manual):
-    - [ocrd-segment-evaluate](ocrd_segment/evaluate.py) :construction: (very early stage)
-  - repairing layout segmentations (input file groups N >= 1, based on heuristics implemented using Shapely):
-    - [ocrd-segment-repair](ocrd_segment/repair.py) :construction: (much to be done)
   - importing layout segmentations from other formats (mask images, MS-COCO JSON annotation):
     - [ocrd-segment-from-masks](ocrd_segment/import_image_segmentation.py)
-    - [ocrd-segment-from-coco](ocrd_segment/import_coco_segmentation.py) :construction: (unpublished)
+    - [ocrd-segment-from-coco](ocrd_segment/import_coco_segmentation.py)
+  - repairing layout segmentations (input file groups N >= 1, based on heuristics implemented using Shapely):
+    - [ocrd-segment-repair](ocrd_segment/repair.py) :construction: (much to be done)
+  - comparing different layout segmentations (input file groups N = 2, compute the distance between two segmentations, e.g. automatic vs. manual):
+    - [ocrd-segment-evaluate](ocrd_segment/evaluate.py) :construction: (very early stage)
   - pattern-based segmentation (input file groups N=1, based on a PAGE template, e.g. from Aletheia, and some XSLT or Python to apply it to the input file group)
     - `ocrd-segment-via-template` :construction: (unpublished)
   - data-driven segmentation (input file groups N=1, based on a statistical model, e.g. Neural Network)  

--- a/ocrd_segment/__init__.py
+++ b/ocrd_segment/__init__.py
@@ -3,3 +3,4 @@ from .evaluate import EvaluateSegmentation
 from .extract_regions import ExtractRegions
 from .extract_lines import ExtractLines
 from .import_image_segmentation import ImportImageSegmentation
+from .import_coco_segmentation import ImportCOCOSegmentation

--- a/ocrd_segment/__init__.py
+++ b/ocrd_segment/__init__.py
@@ -2,3 +2,4 @@ from .repair import RepairSegmentation
 from .evaluate import EvaluateSegmentation
 from .extract_regions import ExtractRegions
 from .extract_lines import ExtractLines
+from .import_image_segmentation import ImportImageSegmentation

--- a/ocrd_segment/cli.py
+++ b/ocrd_segment/cli.py
@@ -1,16 +1,22 @@
 import click
 
 from ocrd.decorators import ocrd_cli_options, ocrd_cli_wrap_processor
-from ocrd_segment.repair import RepairSegmentation
-from ocrd_segment.evaluate import EvaluateSegmentation
-from ocrd_segment.extract_pages import ExtractPages
-from ocrd_segment.extract_regions import ExtractRegions
-from ocrd_segment.extract_lines import ExtractLines
+from .repair import RepairSegmentation
+from .import_image_segmentation import ImportImageSegmentation
+from .evaluate import EvaluateSegmentation
+from .extract_pages import ExtractPages
+from .extract_regions import ExtractRegions
+from .extract_lines import ExtractLines
 
 @click.command()
 @ocrd_cli_options
 def ocrd_segment_repair(*args, **kwargs):
     return ocrd_cli_wrap_processor(RepairSegmentation, *args, **kwargs)
+
+@click.command()
+@ocrd_cli_options
+def ocrd_segment_from_masks(*args, **kwargs):
+    return ocrd_cli_wrap_processor(ImportImageSegmentation, *args, **kwargs)
 
 @click.command()
 @ocrd_cli_options

--- a/ocrd_segment/cli.py
+++ b/ocrd_segment/cli.py
@@ -3,6 +3,7 @@ import click
 from ocrd.decorators import ocrd_cli_options, ocrd_cli_wrap_processor
 from .repair import RepairSegmentation
 from .import_image_segmentation import ImportImageSegmentation
+from .import_coco_segmentation import ImportCOCOSegmentation
 from .evaluate import EvaluateSegmentation
 from .extract_pages import ExtractPages
 from .extract_regions import ExtractRegions
@@ -17,6 +18,11 @@ def ocrd_segment_repair(*args, **kwargs):
 @ocrd_cli_options
 def ocrd_segment_from_masks(*args, **kwargs):
     return ocrd_cli_wrap_processor(ImportImageSegmentation, *args, **kwargs)
+
+@click.command()
+@ocrd_cli_options
+def ocrd_segment_from_coco(*args, **kwargs):
+    return ocrd_cli_wrap_processor(ImportCOCOSegmentation, *args, **kwargs)
 
 @click.command()
 @ocrd_cli_options

--- a/ocrd_segment/extract_pages.py
+++ b/ocrd_segment/extract_pages.py
@@ -2,16 +2,23 @@ from __future__ import absolute_import
 
 import json
 from PIL import Image, ImageDraw
+from shapely.geometry import Polygon
 
 from ocrd_utils import (
     getLogger, concat_padded,
     coordinates_of_segment,
+    xywh_from_polygon,
     MIME_TO_EXT
 )
 from ocrd_models.ocrd_page import (
     LabelsType, LabelType,
     MetadataItemType
 )
+from ocrd_models.ocrd_page_generateds import (
+    TextTypeSimpleType,
+    GraphicsTypeSimpleType,
+    ChartTypeSimpleType
+)    
 from ocrd_modelfactory import page_from_file
 from ocrd import Processor
 
@@ -51,22 +58,76 @@ class ExtractPages(Processor):
         Get all regions with their types (region element class), sub-types (@type)
         and coordinates relative to the page (which depending on the workflow could
         already be cropped, deskewed, dewarped, binarized etc). Extract the image of
-        the page, both in binarized and non-binarized form. In addition, create a new
-        image which color-codes all regions. Create a JSON file with region types and
-        coordinates.
+        the (cropped, deskewed, dewarped) page, both in binarized form (if available)
+        and non-binarized form. In addition, create a new image with masks for all
+        regions, color-coded by type. Create two JSON files with region types and
+        coordinates: one (page-wise) in our custom format and one (global) in MS-COCO.
         
-        Write all files in the directory of the output file group, named like so:
-        * ID + '.png': raw image
-        * ID + '.bin.png': binarized image
-        * ID + '.dbg.png': debug image
-        * ID + '.json': region coordinates
+        The output file group may be given as a comma-separated list to separate
+        these 3 page-level images. Write files as follows:
+        * in the directory of the first (or only) output file group:
+          - ID + '.png': raw image of the (preprocessed) page
+          - ID + '.json': region coordinates/classes (custom format)
+        * in the directory of the second (or first) output file group:
+          - ID + '.bin.png': binarized image of the (preprocessed) page, if available
+        * in the directory of the third (or first) output file group:
+          - ID + '.dbg.png': debug image
+        
+        In addition, write a file for all pages in the parent directory, named like so:
+        * output_file_grp + '.coco.json': region coordinates/classes (MS-COCO)
         
         (This is intended for training and evaluation of region segmentation models.)
         """
+        file_groups = self.output_file_grp.split(',')
+        if len(file_groups) > 3:
+            raise Exception("at most 3 output file grps allowed (raw, [binarized, [debug]] image)")
+        if len(file_groups) > 2:
+            dbg_image_grp = file_groups[2]
+        else:
+            dbg_image_grp = file_groups[0]
+            LOG.info("No output file group for debug images specified, falling back to output filegrp '%s'", dbg_image_grp)
+        if len(file_groups) > 1:
+            bin_image_grp = file_groups[1]
+        else:
+            bin_image_grp = file_groups[0]
+            LOG.info("No output file group for binarized images specified, falling back to output filegrp '%s'", bin_image_grp)
+        self.output_file_grp = file_groups[0]
+        
+        # COCO: init data structures
+        images = list()
+        annotations = list()
+        categories = list()
+        i = 0
+        for cat, color in CLASSES.items():
+            categories.append(
+                {'id': i, 'name': cat, 'supercategory': '',
+                 'source': 'PAGE', 'color': color})
+            i += 1
+        typedict = {"text": TextTypeSimpleType,
+                    "graphic": GraphicsTypeSimpleType,
+                    "chart": ChartTypeSimpleType}
+        i = len(categories)
+        SUPERCLASSES = dict()
+        for supercat, class_ in typedict.items():
+            j = i
+            for name, cat in vars(class_).items():
+                if name[0] != '_':
+                    color = list(CLASSES[supercat])
+                    for c in range(3):
+                        if not color[c]:
+                            color[c] = (i-j+1) * 5
+                    SUPERCLASSES[(cat, supercat)] = tuple(color)
+                    categories.append(
+                        {'id': i, 'name': cat, 'supercategory': supercat,
+                         'source': 'PAGE', 'color': color})
+                    i += 1
+
+        i = 0
         # pylint: disable=attribute-defined-outside-init
         for n, input_file in enumerate(self.input_files):
             file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
             page_id = input_file.pageId or input_file.ID
+            num_page_id = int(page_id.strip(page_id.strip("0123456789")))
             LOG.info("INPUT FILE %i / %s", n, page_id)
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page = pcgts.get_Page()
@@ -97,14 +158,20 @@ class ExtractPages(Processor):
                                                        self.output_file_grp,
                                                        page_id=page_id,
                                                        mimetype=self.parameter['mimetype'])
-            page_image_bin, _, _ = self.workspace.image_from_page(
-                page, page_id,
-                feature_selector='binarized',
-                transparency=self.parameter['transparency'])
-            self.workspace.save_image_file(page_image_bin,
-                                           file_id + '.bin',
-                                           self.output_file_grp,
-                                           page_id=page_id)
+            try:
+                page_image_bin, _, _ = self.workspace.image_from_page(
+                    page, page_id,
+                    feature_selector='binarized',
+                    transparency=self.parameter['transparency'])
+                self.workspace.save_image_file(page_image_bin,
+                                               file_id + '.bin',
+                                               bin_image_grp,
+                                               page_id=page_id)
+            except Exception as err:
+                if err.args[0].startswith('Found no AlternativeImage'):
+                    LOG.warning('Page "%s" has no binarized images, skipping .bin', page_id)
+                else:
+                    raise
             page_image_dbg = Image.new(mode='RGB', size=page_image.size, color=0)
             regions = { 'text': page.get_TextRegion(),
                         'table': page.get_TableRegion(),
@@ -122,12 +189,18 @@ class ExtractPages(Processor):
             description = { 'angle': page.get_orientation() }
             for rtype, rlist in regions.items():
                 for region in rlist:
+                    subrtype = region.get_type() if rtype in ['text', 'chart', 'graphic'] else None
                     polygon = coordinates_of_segment(
-                        region, page_image, page_coords).tolist()
+                        region, page_image, page_coords)
+                    polygon2 = polygon.reshape(1,-1).tolist()
+                    polygon = polygon.tolist()
+                    xywh = xywh_from_polygon(polygon)
+                    area = Polygon(polygon).area
                     description.setdefault('regions', []).append(
                         { 'type': rtype,
-                          'subtype': region.get_type() if rtype in ['text', 'chart', 'graphic'] else None,
+                          'subtype': subrtype,
                           'coords': polygon,
+                          'area': area,
                           'features': page_coords['features'],
                           'DPI': dpi,
                           'region.ID': region.id,
@@ -136,14 +209,42 @@ class ExtractPages(Processor):
                           'file_grp': self.input_file_grp,
                           'METS.UID': self.workspace.mets.unique_identifier
                         })
-                    ImageDraw.Draw(page_image_dbg).polygon(list(map(tuple, polygon)),
-                                                               fill=CLASSES[rtype])
-                    ImageDraw.Draw(page_image_dbg).line(list(map(tuple, polygon + [polygon[0]])), 
-                                                            fill=CLASSES['border'], width=3)
+                    # draw region:
+                    ImageDraw.Draw(page_image_dbg).polygon(
+                        list(map(tuple, polygon)),
+                        fill=SUPERCLASSES.get((subrtype, rtype), CLASSES.get(rtype)))
+                    # draw hull:
+                    #ImageDraw.Draw(page_image_dbg).line(
+                    #    list(map(tuple, polygon + [polygon[0]])), 
+                    #    fill=CLASSES['border'], width=3)
+                    # COCO: add annotations
+                    i += 1
+                    annotations.append(
+                        {'id': i, 'image_id': num_page_id,
+                         'category_id': next((cat['id'] for cat in categories if cat['name'] == subrtype),
+                                             next((cat['id'] for cat in categories if cat['name'] == rtype))),
+                         'segmentation': polygon2,
+                         'area': area,
+                         'bbox': [xywh['x'], xywh['y'], xywh['w'], xywh['h']],
+                         'iscrowd': 0})
+            
             self.workspace.save_image_file(page_image_dbg,
                                            file_id + '.dbg',
-                                           self.output_file_grp,
+                                           dbg_image_grp,
                                            page_id=page_id,
                                            mimetype=self.parameter['mimetype'])
             file_path = file_path.replace(MIME_TO_EXT[self.parameter['mimetype']], '.json')
-            json.dump(description, open(file_path, 'w'))
+            with open(file_path, 'w') as out:
+                json.dump(description, out)
+
+            # COCO: add image
+            images.append(
+                {'id': num_page_id, 'file_name': page.imageFilename,
+                 'width': page_image.width, 'height': page_image.height})
+        
+        # COCO: write result
+        with open(self.output_file_grp + '.coco.json', 'w') as coco:
+            json.dump({'categories': categories,
+                       'images': images,
+                       'annotations': annotations},
+                      coco)

--- a/ocrd_segment/import_coco_segmentation.py
+++ b/ocrd_segment/import_coco_segmentation.py
@@ -1,0 +1,257 @@
+from __future__ import absolute_import
+
+import os.path
+import json
+import logging
+import numpy as np
+
+from ocrd_utils import (
+    getLogger,
+    concat_padded,
+    points_from_polygon,
+    MIMETYPE_PAGE,
+    membername
+)
+from ocrd_modelfactory import page_from_file
+# pragma pylint: disable=unused-import
+# (region types will be referenced indirectly via globals())
+from ocrd_models.ocrd_page import (
+    MetadataItemType,
+    LabelsType, LabelType,
+    CoordsType,
+    TextRegionType,
+    ImageRegionType,
+    MathsRegionType,
+    SeparatorRegionType,
+    NoiseRegionType,
+    to_xml)
+from ocrd_models.ocrd_page_generateds import (
+    BorderType,
+    TableRegionType,
+    GraphicRegionType,
+    ChartRegionType,
+    ChemRegionType,
+    LineDrawingRegionType,
+    MusicRegionType,
+    UnknownRegionType,
+    AdvertRegionType,
+    CustomRegionType,
+    MapRegionType,
+    TextTypeSimpleType,
+    GraphicsTypeSimpleType,
+    ChartTypeSimpleType
+)
+# pragma pylint: enable=unused-import
+from ocrd import Processor
+
+from .config import OCRD_TOOL
+
+TOOL = 'ocrd-segment-from-coco'
+LOG = getLogger('processor.ImportCOCOSegmentation')
+
+class ImportCOCOSegmentation(Processor):
+
+    def __init__(self, *args, **kwargs):
+        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
+        kwargs['version'] = OCRD_TOOL['version']
+        super(ImportCOCOSegmentation, self).__init__(*args, **kwargs)
+
+    def process(self):
+        """Performs region segmentation by reading from COCO annotations.
+        
+        Open and deserialize the COCO JSON file from the second input file group.
+        (It lists region categories/subtypes, file names and segmentations for all pages.)
+        
+        Open and deserialize each PAGE input file (or generate from image input file)
+        from the first input file group. Now find this page in COCO:
+        - try to match the PAGE ``imageFilename`` or METS file path matches to some
+          COCO ``file_name``, otherwise
+        - try to match the numeric part of the METS physical page ID to some
+          COCO ``id``, otherwise
+        - skip with an error.
+        
+        Then create and add a region for each ``segmentation``, converting its polygon
+        to coordinate points and its COCO category to a region type (and subtype),
+        either for a PubLayNet classification or PAGE classification (as produced by
+        ocrd-segment-extract-pages), as indicated by ``source``.
+        
+        Produce a new output file by serialising the resulting hierarchy.
+        
+        Afterwards, if there are still COCO images left unaccounted for (i.e. without
+        corresponding input files), then show a warning.
+        """
+        # Load JSON
+        try:
+            # pylint: disable=attribute-defined-outside-init
+            self.input_file_grp, coco_grp = self.input_file_grp.split(',')
+        except ValueError:
+            raise Exception("need 2 input file groups (base and COCO)")
+        # pylint: disable=attribute-defined-outside-init
+        if not self.input_files:
+            LOG.warning('No input files to process')
+            return
+        if coco_grp in self.workspace.mets.file_groups:
+            try:
+                cocofile = next(f for f in self.workspace.mets.find_files(fileGrp=coco_grp)
+                                # if f.mimetype == 'application/json' and not f.pageId
+                                if not f.pageId)
+            except StopIteration:
+                raise Exception("no non-page-specific file in second file group (COCO file)", coco_grp)
+            cocofile = self.workspace.download_file(cocofile).local_filename
+        elif os.path.isfile(coco_grp):
+            cocofile = coco_grp
+        else:
+            raise Exception("file not found in second file group (COCO file)", coco_grp)
+        
+        LOG.info('Loading COCO annotations from "%s" into memory...', cocofile)
+        with open(cocofile, 'r') as inp:
+            coco = json.load(inp)
+        LOG.info('Loaded JSON for %d images with %d regions in %d categories',
+                 len(coco['images']), len(coco['annotations']), len(coco['categories']))
+        coco_source = 'PubLayNet'
+        # Convert to usable dicts
+        # classes:
+        categories = dict()
+        subcategories = dict()
+        for cat in coco['categories']:
+            if cat['source'] == 'PAGE':
+                coco_source = 'PAGE'
+            if 'supercategory' in cat and cat['supercategory']:
+                categories[cat['id']] = cat['supercategory']
+                subcategories[cat['id']] = cat['name']
+            else:
+                categories[cat['id']] = cat['name']
+        # images and annotations:
+        images_by_id = dict()
+        images_by_filename = dict()
+        for image in coco['images']:
+            images_by_id[image['id']] = image
+            images_by_filename[image['file_name']] = image
+        for annotation in coco['annotations']:
+            image = images_by_id[annotation['image_id']]
+            regions = image.setdefault('regions', list())
+            regions.append(annotation)
+        del coco
+        
+        LOG.info('Converting %s annotations into PAGE-XML', coco_source)
+        for n, input_file in enumerate(self.input_files):
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
+            page_id = input_file.pageId or input_file.ID
+            num_page_id = int(page_id.strip(page_id.strip("0123456789")))
+            LOG.info("INPUT FILE %i / %s", n, page_id)
+            pcgts = page_from_file(self.workspace.download_file(input_file))
+            page = pcgts.get_Page()
+
+            # add metadata about this operation and its runtime parameters:
+            metadata = pcgts.get_Metadata() # ensured by from_file()
+            metadata.add_MetadataItem(
+                MetadataItemType(type_="processingStep",
+                                 name=self.ocrd_tool['steps'][0],
+                                 value=TOOL,
+                                 Labels=[LabelsType(
+                                     externalModel="ocrd-tool",
+                                     externalId="parameters",
+                                     Label=[LabelType(type_=name,
+                                                      value=self.parameter[name])
+                                            for name in self.parameter.keys()])]))
+
+            # find COCO image
+            if page.imageFilename in images_by_filename:
+                image = images_by_filename[page.imageFilename]
+            elif num_page_id in images_by_id:
+                image = images_by_id[num_page_id]
+            else:
+                LOG.error('Page "%s" / file "%s" not found in COCO',
+                          page_id, page.imageFilename)
+                # todo: maybe we should at least write the (unchanged) output PAGE?
+                continue
+            if image['width'] != page.imageWidth:
+                LOG.error('Page "%s" width %d does not match annotated width %d',
+                          page_id, page.imageWidth, image['width'])
+            if image['height'] != page.imageHeight:
+                LOG.error('Page "%s" height %d does not match annotated height %d',
+                          page_id, page.imageHeight, image['height'])
+
+            # todo: remove existing segmentation first?
+            for region in image['regions']:
+                assert isinstance(region['segmentation'], list), "importing RLE/mask segmentation not implemented"
+                polygon = np.array(region['segmentation'])
+                polygon = np.reshape(polygon, (polygon.shape[1]//2, 2))
+                coords = CoordsType(points=points_from_polygon(polygon))
+                category = categories[region['category_id']]
+                if region['category_id'] in subcategories:
+                    subcategory = subcategories[region['category_id']]
+                else:
+                    subcategory = None
+                region_id = 'r' + str(region['id'])
+                LOG.info('Adding region %s:%s [area %d]', category, subcategory or '', region['area'])
+                if coco_source == 'PubLayNet':
+                    if category == 'text':
+                        region_obj = TextRegionType(id=region_id, Coords=coords,
+                                                    type_=TextTypeSimpleType.PARAGRAPH)
+                        page.add_TextRegion(region_obj)
+                    elif category == 'title':
+                        region_obj = TextRegionType(id=region_id, Coords=coords,
+                                                    type_=TextTypeSimpleType.HEADING) # CAPTION?
+                        page.add_TextRegion(region_obj)
+                    elif category == 'list':
+                        region_obj = TextRegionType(id=region_id, Coords=coords,
+                                                    type_=TextTypeSimpleType.LISTLABEL) # OTHER?
+                        page.add_TextRegion(region_obj)
+                    elif category == 'table':
+                        region_obj = TableRegionType(id=region_id, Coords=coords)
+                        page.add_TableRegion(region_obj)
+                    elif category == 'figure':
+                        region_obj = ImageRegionType(id=region_id, Coords=coords)
+                        page.add_ImageRegion(region_obj)
+                    else:
+                        raise Exception('unknown region category: %s' % category)
+                else: # 'PAGE'
+                    args = {'id': region_id,
+                            'Coords': coords}
+                    if subcategory:
+                        typedict = {"TextRegion": TextTypeSimpleType,
+                                    "GraphicRegion": GraphicsTypeSimpleType,
+                                    "ChartType": ChartTypeSimpleType}
+                        if category in typedict:
+                            subtype = membername(typedict[category], subcategory)
+                            if subtype == subcategory:
+                                # not predefined in PAGE: use other + custom
+                                args['custom'] = "subtype:%s" % subcategory
+                                args['type_'] = "other"
+                            else:
+                                args['type_'] = subcategory
+                        else:
+                            args['custom'] = "subtype:%s" % subcategory
+                    if category + 'Type' not in globals():
+                        raise Exception('unknown region category: %s' % category)
+                    region_type = globals()[category + 'Type']
+                    if region_type is BorderType:
+                        page.set_Border(BorderType(Coords=coords))
+                    else:
+                        region_obj = region_type(**args)
+                        getattr(page, 'add_%s' % category)(region_obj)
+            # remove image from dicts
+            images_by_id.pop(num_page_id, None)
+            images_by_filename.pop(page.imageFilename, None)
+                    
+            # Use input_file's basename for the new file -
+            # this way the files retain the same basenames:
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
+            if file_id == input_file.ID:
+                file_id = concat_padded(self.output_file_grp, n)
+            self.workspace.add_file(
+                ID=file_id,
+                file_grp=self.output_file_grp,
+                pageId=input_file.pageId,
+                mimetype=MIMETYPE_PAGE,
+                local_filename=os.path.join(self.output_file_grp,
+                                            file_id + '.xml'),
+                content=to_xml(pcgts))
+        
+        # warn of remaining COCO images
+        if images_by_filename and not self.page_id:
+            LOG.warning('%d images remain unaccounted for after processing', len(images_by_filename))
+            if LOG.isEnabledFor(logging.DEBUG):
+                for filename in images_by_filename:
+                    LOG.debug('not found in workspace: "%s"', filename)

--- a/ocrd_segment/import_image_segmentation.py
+++ b/ocrd_segment/import_image_segmentation.py
@@ -43,6 +43,7 @@ from ocrd_models.ocrd_page_generateds import (
 from ocrd import Processor
 
 from .config import OCRD_TOOL
+from .extract_pages import CLASSES
 
 TOOL = 'ocrd-segment-from-masks'
 LOG = getLogger('processor.ImportImageSegmentation')
@@ -68,6 +69,11 @@ class ImportImageSegmentation(Processor):
         Produce a new output file by serialising the resulting hierarchy.
         """
         colordict = self.parameter['colordict']
+        if not colordict:
+            LOG.info('Using default PAGE colordict')
+            colordict = dict(('#' + col, name)
+                             for name, col in CLASSES.items()
+                             if name)
         typedict = {"TextRegion": TextTypeSimpleType,
                     "GraphicRegion": GraphicsTypeSimpleType,
                     "ChartType": ChartTypeSimpleType}

--- a/ocrd_segment/import_image_segmentation.py
+++ b/ocrd_segment/import_image_segmentation.py
@@ -1,0 +1,205 @@
+from __future__ import absolute_import
+
+import os.path
+from PIL import Image
+import numpy as np
+import cv2
+
+from ocrd_utils import (
+    getLogger,
+    concat_padded,
+    points_from_polygon,
+    MIMETYPE_PAGE,
+    pushd_popd,
+    membername
+)
+from ocrd_modelfactory import page_from_file
+from ocrd_models.ocrd_page import (
+    MetadataItemType,
+    LabelsType, LabelType,
+    CoordsType, AlternativeImageType,
+    TextRegionType,
+    ImageRegionType,
+    MathsRegionType,
+    SeparatorRegionType,
+    NoiseRegionType,
+    to_xml)
+from ocrd_models.ocrd_page_generateds import (
+    TableRegionType,
+    GraphicRegionType,
+    ChartRegionType,
+    ChemRegionType,
+    LineDrawingRegionType,
+    MusicRegionType,
+    UnknownRegionType,
+    TextTypeSimpleType,
+    GraphicsTypeSimpleType,
+    ChartTypeSimpleType
+)
+from ocrd import Processor
+
+from .config import OCRD_TOOL
+
+TOOL = 'ocrd-segment-from-masks'
+LOG = getLogger('processor.ImportImageSegmentation')
+
+class ImportImageSegmentation(Processor):
+
+    def __init__(self, *args, **kwargs):
+        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
+        kwargs['version'] = OCRD_TOOL['version']
+        super(ImportImageSegmentation, self).__init__(*args, **kwargs)
+
+    def process(self):
+        """Performs region segmentation by reading mask images in pseudo-colour.
+        
+        Open and deserialize each PAGE input file (or generate from image input file)
+        from the first input file group, as well as mask image file from the second.
+        
+        Then iterate over all connected (equally colored) mask segments and compute
+        convex hull contours for them. Convert them to polygons, and look up their
+        color value in ``colordict`` to instantiate the appropriate region types
+        (optionally with subtype). Instantiate and annotate regions accordingly.
+        
+        Produce a new output file by serialising the resulting hierarchy.
+        """
+        colordict = self.parameter['colordict']
+        typedict = {"TextRegion": TextTypeSimpleType,
+                    "GraphicRegion": GraphicsTypeSimpleType,
+                    "ChartType": ChartTypeSimpleType}
+        ifgs = self.input_file_grp.split(",") # input file groups
+        if len(ifgs) != 2:
+            raise Exception("need 2 input file groups (base and mask)")
+        # collect input file tuples
+        ifts = self.zip_input_files(ifgs) # input file tuples
+        # process input file tuples
+        for n, ift in enumerate(ifts):
+            input_file, segmentation_file = ift
+            LOG.info("processing page %s", input_file.pageId)
+            pcgts = page_from_file(self.workspace.download_file(input_file))
+            page = pcgts.get_Page()
+
+            # add metadata about this operation and its runtime parameters:
+            metadata = pcgts.get_Metadata() # ensured by from_file()
+            metadata.add_MetadataItem(
+                MetadataItemType(type_="processingStep",
+                                 name=self.ocrd_tool['steps'][0],
+                                 value=TOOL,
+                                 Labels=[LabelsType(
+                                     externalModel="ocrd-tool",
+                                     externalId="parameters",
+                                     Label=[LabelType(type_=name,
+                                                      value=self.parameter[name])
+                                            for name in self.parameter.keys()])]))
+            
+            segmentation_filename = self.workspace.download_file(segmentation_file).local_filename
+            with pushd_popd(self.workspace.directory):
+                segmentation_pil = Image.open(segmentation_filename)
+            if segmentation_pil.mode != 'RGB':
+                segmentation_pil = segmentation_pil.convert('RGB')
+            # convert to array
+            segmentation_array = np.array(segmentation_pil)
+            # collapse 3 color channels
+            segmentation_array = segmentation_array.dot(np.array([2**16, 2**8, 1], np.uint32))
+            # iterate over mask for each color/class
+            regionno = 0
+            colors = np.unique(segmentation_array)
+            for color in colors:
+                if not "#%06X" % color in colordict:
+                    #raise Exception("Unknown color #%06X (not in colordict)" % color)
+                    LOG.info("Ignoring background color #%06X", color)
+                    continue
+                # get region (sub)type
+                classname = colordict["#%06X" % color]
+                regiontype = None
+                custom = None
+                if ":" in classname:
+                    classname, regiontype = classname.split(":")
+                    if classname in typedict:
+                        typename = membername(typedict[classname], regiontype)
+                        if typename == regiontype:
+                            # not predefined in PAGE: use other + custom
+                            custom = "subtype:%s" % regiontype
+                            regiontype = "other"
+                    else:
+                        custom = "subtype:%s" % regiontype
+                if classname + "Type" not in globals():
+                    raise Exception("Unknown class '%s' for color #%06X in colordict" % (classname, color))
+                classtype = globals()[classname + "Type"]
+                # mask image by current color/class
+                classmask = np.array(segmentation_array == color, np.uint8)
+                if not np.count_nonzero(classmask):
+                    continue
+                # now get the contours and make polygons for them
+                contours, _ = cv2.findContours(classmask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+                for contour in contours:
+                    # (could also just take bounding boxes to avoid islands/inclusions...)
+                    area = cv2.contourArea(contour)
+                    # filter too small regions
+                    area_pct = area / np.prod(segmentation_array.shape) * 100
+                    if area < 100 and area_pct < 0.1:
+                        LOG.warning('ignoring contour of only %d%% area for color #%06X',
+                                    area_pct, color)
+                        continue
+                    LOG.info('found region %s:%s:%s with area %d%%',
+                             classname, regiontype or 'none', custom or 'none', area_pct)
+                    # simplify shape
+                    poly = cv2.approxPolyDP(contour, 2, False)[:, 0, ::] # already ordered x,y
+                    if len(poly) < 4:
+                        LOG.warning('ignoring contour of only %d points (area %d%%) for color #%06X',
+                                    len(poly), area_pct, color)
+                        continue
+                    # instantiate region
+                    regionno += 1
+                    region = classtype(id="region_%d" % regionno, type_=regiontype, custom=custom,
+                                       Coords=CoordsType(points=points_from_polygon(poly)))
+                    # add region
+                    getattr(page, 'add_%s' % classname)(region)
+                    
+            # Use input_file's basename for the new file -
+            # this way the files retain the same basenames:
+            file_id = input_file.ID.replace(ifgs[0], self.output_file_grp)
+            if file_id == input_file.ID:
+                file_id = concat_padded(self.output_file_grp, n)
+            self.workspace.add_file(
+                ID=file_id,
+                file_grp=self.output_file_grp,
+                pageId=input_file.pageId,
+                mimetype=MIMETYPE_PAGE,
+                local_filename=os.path.join(self.output_file_grp,
+                                            file_id + '.xml'),
+                content=to_xml(pcgts))
+            
+    def zip_input_files(self, ifgs):
+        """Get a list (for each physical page) of tuples (for each input file group) of METS files."""
+        ifts = list() # file tuples
+        if self.page_id:
+            pages = [self.page_id]
+        else:
+            pages = self.workspace.mets.physical_pages
+        for page_id in pages:
+            ifiles = list()
+            for ifg in ifgs:
+                LOG.debug("adding input file group %s to page %s", ifg, page_id)
+                files = self.workspace.mets.find_files(pageId=page_id, fileGrp=ifg)
+                if not files:
+                    # fall back for missing pageId via Page imageFilename:
+                    all_files = self.workspace.mets.find_files(fileGrp=ifg)
+                    for file_ in all_files:
+                        pcgts = page_from_file(self.workspace.download_file(file_))
+                        image_url = pcgts.get_Page().get_imageFilename()
+                        img_files = self.workspace.mets.find_files(url=image_url)
+                        if img_files and img_files[0].pageId == page_id:
+                            files = [file_]
+                            break
+                if not files:
+                    # other fallback options?
+                    LOG.error('found no page %s in file group %s',
+                              page_id, ifg)
+                    ifiles.append(None)
+                else:
+                    ifiles.append(files[0])
+            if ifiles[0]:
+                ifts.append(tuple(ifiles))
+        return ifts
+            

--- a/ocrd_segment/ocrd-tool.json
+++ b/ocrd_segment/ocrd-tool.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.3",
+  "version": "0.0.4",
   "git_url": "https://github.com/OCR-D/ocrd_segment",
   "tools": {
     "ocrd-segment-repair": {

--- a/ocrd_segment/ocrd-tool.json
+++ b/ocrd_segment/ocrd-tool.json
@@ -53,6 +53,28 @@
         }
       }
     },
+    "ocrd-segment-from-coco": {
+      "executable": "ocrd-segment-from-coco",
+      "categories": ["Layout analysis"],
+      "description": "Import region segmentation from COCO format",
+      "input_file_grp": [
+        "OCR-D-IMG",
+        "OCR-D-SEG-PAGE"
+      ],
+      "output_file_grp": [
+        "OCR-D-SEG-BLOCK"
+      ],
+      "steps": ["layout/segmentation/region"],
+      "parameters": {
+        "cocofile": {
+          "type": "string",
+          "format": "uri",
+          "content-type": "application/json",
+          "required": true,
+          "description": "JSON file with image segmentations in COCO detection format (source PubLayNet or PAGE)"
+        }
+      }
+    },
     "ocrd-segment-extract-pages": {
       "executable": "ocrd-segment-extract-pages",
       "categories": ["Image preprocessing"],

--- a/ocrd_segment/ocrd-tool.json
+++ b/ocrd_segment/ocrd-tool.json
@@ -33,6 +33,26 @@
         }
       }
     },
+    "ocrd-segment-from-masks": {
+      "executable": "ocrd-segment-from-masks",
+      "categories": ["Layout analysis"],
+      "description": "Import region segmentation from mask images",
+      "input_file_grp": [
+        "OCR-D-IMG",
+        "OCR-D-SEG-PAGE"
+      ],
+      "output_file_grp": [
+        "OCR-D-SEG-BLOCK"
+      ],
+      "steps": ["layout/segmentation/region"],
+      "parameters": {
+        "colordict": {
+          "type": "object",
+          "required": true,
+          "description": "mapping from color values in the input masks to region types to annotate; color must be encoded hexadecimal (e.g. '#00FF00'); region type equals the element name in PAGE-XML, optionally followed by a colon and a subtype (e.g. 'TextRegion:paragraph'; unmapped colors will be ignored (i.e. treated as background))"
+        }
+      }
+    },
     "ocrd-segment-extract-pages": {
       "executable": "ocrd-segment-extract-pages",
       "categories": ["Image preprocessing"],

--- a/ocrd_segment/ocrd-tool.json
+++ b/ocrd_segment/ocrd-tool.json
@@ -48,8 +48,8 @@
       "parameters": {
         "colordict": {
           "type": "object",
-          "required": true,
-          "description": "Mapping from color values in the input masks to region types to annotate; color must be encoded hexadecimal (e.g. '#00FF00'); region type equals the element name in PAGE-XML, optionally followed by a colon and a subtype (e.g. 'TextRegion:paragraph'; unmapped colors will be ignored (i.e. treated as background)). Cf. output of ocrd-segment-extract-pages for an example."
+          "default": {},
+          "description": "Mapping from color values in the input masks to region types to annotate; color must be encoded hexadecimal (e.g. '#00FF00'); region type equals the element name in PAGE-XML, optionally followed by a colon and a subtype (e.g. 'TextRegion:paragraph'; unmapped colors will be ignored (i.e. treated as background)). Cf. output of ocrd-segment-extract-pages for an example (this is also the default)."
         }
       }
     },

--- a/ocrd_segment/ocrd-tool.json
+++ b/ocrd_segment/ocrd-tool.json
@@ -36,7 +36,7 @@
     "ocrd-segment-from-masks": {
       "executable": "ocrd-segment-from-masks",
       "categories": ["Layout analysis"],
-      "description": "Import region segmentation from mask images",
+      "description": "Import region segmentation from mask images (segments filled with colors encoding classes). Input fileGrp format is `base,mask` (i.e. PAGE or original image files first, mask image files second).",
       "input_file_grp": [
         "OCR-D-IMG",
         "OCR-D-SEG-PAGE"
@@ -49,14 +49,14 @@
         "colordict": {
           "type": "object",
           "required": true,
-          "description": "mapping from color values in the input masks to region types to annotate; color must be encoded hexadecimal (e.g. '#00FF00'); region type equals the element name in PAGE-XML, optionally followed by a colon and a subtype (e.g. 'TextRegion:paragraph'; unmapped colors will be ignored (i.e. treated as background))"
+          "description": "Mapping from color values in the input masks to region types to annotate; color must be encoded hexadecimal (e.g. '#00FF00'); region type equals the element name in PAGE-XML, optionally followed by a colon and a subtype (e.g. 'TextRegion:paragraph'; unmapped colors will be ignored (i.e. treated as background)). Cf. output of ocrd-segment-extract-pages for an example."
         }
       }
     },
     "ocrd-segment-from-coco": {
       "executable": "ocrd-segment-from-coco",
       "categories": ["Layout analysis"],
-      "description": "Import region segmentation from COCO format",
+      "description": "Import region segmentation from COCO detection format JSON (for all pages). Input fileGrp format is `base,COCO` (i.e. PAGE or original image files first, COCO file second).",
       "input_file_grp": [
         "OCR-D-IMG",
         "OCR-D-SEG-PAGE"
@@ -66,19 +66,12 @@
       ],
       "steps": ["layout/segmentation/region"],
       "parameters": {
-        "cocofile": {
-          "type": "string",
-          "format": "uri",
-          "content-type": "application/json",
-          "required": true,
-          "description": "JSON file with image segmentations in COCO detection format (source PubLayNet or PAGE)"
-        }
       }
     },
     "ocrd-segment-extract-pages": {
       "executable": "ocrd-segment-extract-pages",
       "categories": ["Image preprocessing"],
-      "description": "Extract page segmentation (border/skew) as image+JSON, including region coordinates/classes.",
+      "description": "Extract page segmentation as page images (deskewed according to `/Page/@orientation` and cropped+masked along `/Page/Border`) + JSON (including region coordinates/classes and meta-data), as binarized images, and as mask images (segments filled with colors encoding classes) + COCO detection format JSON (for all pages). Output fileGrp format is `raw[,binarized[,mask]]` (i.e. fall back to first group).",
       "input_file_grp": [
         "OCR-D-SEG-PAGE",
         "OCR-D-GT-SEG-PAGE",
@@ -106,7 +99,7 @@
     "ocrd-segment-extract-regions": {
       "executable": "ocrd-segment-extract-regions",
       "categories": ["Image preprocessing"],
-      "description": "Extract region segmentation (polygon/skew) as image+JSON.",
+      "description": "Extract region segmentation as region images (deskewed according to `*/@orientation` and cropped+masked along `*/Coords` polygon) + JSON (including region coordinates/classes and meta-data).",
       "input_file_grp": [
         "OCR-D-SEG-BLOCK",
         "OCR-D-GT-SEG-BLOCK"
@@ -132,7 +125,7 @@
     "ocrd-segment-extract-lines": {
       "executable": "ocrd-segment-extract-lines",
       "categories": ["Image preprocessing"],
-      "description": "Extract line segmentation (polygon) as image+txt+JSON.",
+      "description": "Extract line segmentation as line images (deskewed according to `*/@orientation` and cropped+masked along `*/Coords` polygon and dewarped as in `*/AlternativeImage`) + text file (according to `*/TextEquiv`) + JSON (including line coordinates and meta-data).",
       "input_file_grp": [
         "OCR-D-SEG-LINE",
         "OCR-D-GT-SEG-LINE"

--- a/ocrd_segment/repair.py
+++ b/ocrd_segment/repair.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import os.path
 from collections import namedtuple
 from skimage import draw
-from scipy.ndimage import filters
+from scipy.ndimage import filters, morphology
 import cv2
 import numpy as np
 from shapely.geometry import Polygon, LineString
@@ -205,8 +205,7 @@ class RepairSegmentation(Processor):
             scale = int(np.median(np.array(heights)))
             # close labels:
             region_mask = np.pad(region_mask, scale) # protect edges
-            region_mask = filters.maximum_filter(region_mask, (scale, 1), origin=0)
-            region_mask = filters.minimum_filter(region_mask, (scale, 1), origin=0)
+            region_mask = np.array(morphology.binary_closing(region_mask, np.ones((scale, 1))), dtype=np.uint8)
             region_mask = region_mask[scale:-scale, scale:-scale] # unprotect
             # find outer contour (parts):
             contours, _ = cv2.findContours(region_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ Installs:
 
     - ocrd-segment-repair
     - ocrd-segment-from-masks
+    - ocrd-segment-from-coco
     - ocrd-segment-extract-pages
     - ocrd-segment-extract-regions
     - ocrd-segment-extract-lines
@@ -35,6 +36,7 @@ setup(
         'console_scripts': [
             'ocrd-segment-repair=ocrd_segment.cli:ocrd_segment_repair',
             'ocrd-segment-from-masks=ocrd_segment.cli:ocrd_segment_from_masks',
+            'ocrd-segment-from-coco=ocrd_segment.cli:ocrd_segment_from_coco',
             'ocrd-segment-extract-pages=ocrd_segment.cli:ocrd_segment_extract_pages',
             'ocrd-segment-extract-regions=ocrd_segment.cli:ocrd_segment_extract_regions',
             'ocrd-segment-extract-lines=ocrd_segment.cli:ocrd_segment_extract_lines',

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 Installs:
 
     - ocrd-segment-repair
+    - ocrd-segment-from-masks
     - ocrd-segment-extract-pages
     - ocrd-segment-extract-regions
     - ocrd-segment-extract-lines
@@ -33,6 +34,7 @@ setup(
     entry_points={
         'console_scripts': [
             'ocrd-segment-repair=ocrd_segment.cli:ocrd_segment_repair',
+            'ocrd-segment-from-masks=ocrd_segment.cli:ocrd_segment_from_masks',
             'ocrd-segment-extract-pages=ocrd_segment.cli:ocrd_segment_extract_pages',
             'ocrd-segment-extract-regions=ocrd_segment.cli:ocrd_segment_extract_regions',
             'ocrd-segment-extract-lines=ocrd_segment.cli:ocrd_segment_extract_lines',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     version=version,
     description='Page segmentation and segmentation evaluation',
     long_description=codecs.open('README.md', encoding='utf-8').read(),
+    long_description_content_type='text/markdown',
     author='Konstantin Baierer, Kay-Michael Würzner, Robert Sachunsky',
     author_email='unixprog@gmail.com, wuerzner@gmail.com, sachunsky@informatik.uni-leipzig.de',
     url='https://github.com/OCR-D/ocrd_segment',


### PR DESCRIPTION
The basic idea is to get more options and integrate more tools (not necessarily prediction/runtime, but also for GT/training preparation).

However, at this point, I find it hard to anticipate all use-cases. So I did not care about meta-data, or even attempt to get a smooth _round-trip_ yet:

### masks

- from image masks to PAGE via `ocrd-segment-from-masks`: needs a `colordict` param, but can then annotate `@type` (for Text/Chart/GraphicsRegion) and even `@custom=subtype:...` (for all region types)
- from PAGE to image masks via `ocrd-segment-extract-pages`: fixed implicit colordict, also for `@type` (which is probably not always what you want), but ignores `@custom`

So for round trip (though still without `@custom`), you would have to make sure to output debug images into a separate output file group, and then craft a `colordict` yourself:
```JSON
{"colordict":
{
"#C80000": "TextRegion",
"#006414": "TableRegion", 
"#007800": "ChartRegion",
"#008C00": "ChemRegion",
"#0000C8": "GraphicRegion",
"#0014B4": "ImageRegion",
"#1400B4": "LineDrawingRegion",
"#147800": "MathsRegion",
"#147828": "MusicRegion",
"#323232": "NoiseRegion",
"#000064": "SeparatorRegion",
"#000000": "UnknownRegion",
"#C80505": "TextRegion:paragraph",
"#C80A0A": "TextRegion:heading",
"#C80F0F": "TextRegion:caption",
"#C81414": "TextRegion:header",
"#C81919": "TextRegion:footer",
"#C81E1E": "TextRegion:page-number",
"#C82323": "TextRegion:drop-capital",
"#C82828": "TextRegion:credit",
"#C82D2D": "TextRegion:floating",
"#C83232": "TextRegion:signature-mark",
"#C83737": "TextRegion:catch-word",
"#C83C3C": "TextRegion:marginalia",
"#C84141": "TextRegion:footnote",
"#C84646": "TextRegion:footnote-continued",
"#C84B4B": "TextRegion:endnote",
"#C85050": "TextRegion:TOC-entry",
"#C85555": "TextRegion:list-label",
"#C85A5A": "TextRegion:other",
"#0505C8": "GraphicRegion:logo",
"#0A0AC8": "GraphicRegion:letterhead",
"#0F0FC8": "GraphicRegion:decoration",
"#1414C8": "GraphicRegion:frame",
"#1919C8": "GraphicRegion:handwritten-annotation",
"#1E1EC8": "GraphicRegion:stamp",
"#2323C8": "GraphicRegion:signature",
"#2828C8": "GraphicRegion:barcode",
"#2D2DC8": "GraphicRegion:paper-grow",
"#3232C8": "GraphicRegion:punch-hole",
"#3737C8": "GraphicRegion:other",
"#057805": "ChartRegion:bar",
"#0A780A": "ChartRegion:line",
"#0F780F": "ChartRegion:pie",
"#147814": "ChartRegion:scatter",
"#197819": "ChartRegion:surface",
"#1E781E": "ChartRegion:other",
}
}
```

    ocrd-segment-extract-pages -I SEGMENTED -O OCR-D-IMG-PAGES,OCR-D-IMG-PAGES-BIN,OCR-D-IMG-PAGES-DBG
    ocrd-segment-from-masks -I OCR-D-IMG-PAGES,OCR-D-IMG-PAGES-DBG -O SEGMENTED-MASKS -p colordict.json

What's debatable here:
1. should `extract-pages` also have a colordict param, or should `from-masks` assume a default colordict, or is the current asymmetry ok?
2. should `extract-pages` have an option to exclude `@type`? or should it even include `@custom` by default (what colors then)?
3. should `from-masks` assume that if the first input file group is PAGE-XML (and not merely images), then the second input file group represents the mask segmentation of the page frame (cropped to `Border`, deskewed to `@orientation` – if any), or of the source image?

### COCO

- from JSON file to PAGE via `ocrd-segment-from-coco`: needs a `cocofile` param for input, looks at the `source` in its `categories` definitions: 
   * if `"coco"` (as used in [PubLayNet](bertsky/ocrd_publaynet)), then uses the fixed set of region type and `@type` that you would expect for PubLayNet classes, 
   * else assumes `"PAGE"` (as used in `ocrd-segment-extract-pages`) with another fixed set, but relaying everything beyond region types and `@type` to `@custom="subtype:"`)
- from PAGE to JSON via `ocrd-segment-extract-pages`: writes a `OUTFILEGRP.coco.json`, uses fixed implicit colordict, also for `@type` (which is probably not always what you want), but ignores `@custom`

So for round-trip (though still without `@custom`), you could do

    ocrd-segment-extract-pages -I SEGMENTED -O OCR-D-IMG-PAGES,OCR-D-IMG-PAGES-BIN,OCR-D-IMG-PAGES-DBG
    ocrd-segment-from-coco -I OCR-D-IMG-PAGES -O SEGMENTED-COCO -p '{"cocofile": "OCR-D-IMG-PAGES.coco.json"}'

What's debatable here:
1. should `extract-pages` or `from-coco` have an option to exclude `@type` (and `@custom`)?
2. should `from-coco` assume that if the input file group is PAGE-XML (and not merely images), then the COCO segmentation represents the page frame (cropped to `Border`, deskewed to `@orientation` – if any), or the source image?
