### PR TITLE
repair/sanitize: use larger morphological closing kernel...

### DIFF
--- a/ocrd_segment/repair.py
+++ b/ocrd_segment/repair.py
@@ -240,7 +240,10 @@ class RepairSegmentation(Processor):
                                 i, area, total_area, region.id)
                     continue
                 # simplify shape:
-                polygon = cv2.approxPolyDP(contour, 2, False)[:, 0, ::] # already ordered x,y
+                # can produce invalid (self-intersecting) polygons:
+                #polygon = cv2.approxPolyDP(contour, 2, False)[:, 0, ::] # already ordered x,y
+                polygon = contour[:, 0, ::] # already ordered x,y
+                polygon = Polygon(polygon).simplify(1).exterior.coords
                 if len(polygon) < 4:
                     LOG.warning('Ignoring contour %d less than 4 points in region "%s"',
                                 i, region.id)

--- a/ocrd_segment/repair.py
+++ b/ocrd_segment/repair.py
@@ -220,6 +220,8 @@ class RepairSegmentation(Processor):
             region_mask = np.pad(region_mask, scale) # protect edges
             region_mask = np.array(morphology.binary_closing(region_mask, np.ones((scale, 1))), dtype=np.uint8)
             region_mask = region_mask[scale:-scale, scale:-scale] # unprotect
+            # extend margins (to ensure simplified hull polygon is outside children):
+            region_mask = filters.maximum_filter(region_mask, 3) # 1px in each direction
             # find outer contour (parts):
             contours, _ = cv2.findContours(region_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
             # determine areas of parts:


### PR DESCRIPTION
(If interline spacing is larger than line height, prefer the latter.)

– This avoids the `Skipping region ... due to non-contiguous contours` error most of the time.