### PR TITLE
Repair fix coords

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,6 +3,8 @@ ignored-modules=cv2
 
 [MESSAGES CONTROL]
 disable =
+    super-with-arguments,
+    trailing-whitespace,
     missing-docstring,
     no-self-use,
     superfluous-parens,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.1.1] - 2020-09-14
+
+Changed:
+
+  * repair: traverse all text regions recursively
+  
+Fixed:
+
+  * repair: be robust against invalid input polygons
+  * repair: be careful to make valid output polygons
+
 ## [0.1.0] - 2020-08-21
 
 Changed:

--- a/ocrd_segment/extract_lines.py
+++ b/ocrd_segment/extract_lines.py
@@ -11,10 +11,6 @@ from ocrd_utils import (
     polygon_from_points,
     MIME_TO_EXT
 )
-from ocrd_models.ocrd_page import (
-    LabelsType, LabelType,
-    MetadataItemType
-)
 from ocrd_modelfactory import page_from_file
 from ocrd import Processor
 
@@ -75,18 +71,8 @@ class ExtractLines(Processor):
             page_id = input_file.pageId or input_file.ID
             LOG.info("INPUT FILE %i / %s", n, page_id)
             pcgts = page_from_file(self.workspace.download_file(input_file))
+            self.add_metadata(pcgts)
             page = pcgts.get_Page()
-            metadata = pcgts.get_Metadata() # ensured by from_file()
-            metadata.add_MetadataItem(
-                MetadataItemType(type_="processingStep",
-                                 name=self.ocrd_tool['steps'][0],
-                                 value=TOOL,
-                                 Labels=[LabelsType(
-                                     externalModel="ocrd-tool",
-                                     externalId="parameters",
-                                     Label=[LabelType(type_=name,
-                                                      value=self.parameter[name])
-                                            for name in self.parameter.keys()])]))
             page_image, page_coords, page_image_info = self.workspace.image_from_page(
                 page, page_id,
                 transparency=self.parameter['transparency'])

--- a/ocrd_segment/extract_pages.py
+++ b/ocrd_segment/extract_pages.py
@@ -16,10 +16,6 @@ from ocrd_utils import (
     xywh_from_polygon,
     MIME_TO_EXT
 )
-from ocrd_models.ocrd_page import (
-    LabelsType, LabelType,
-    MetadataItemType
-)
 from ocrd_modelfactory import page_from_file
 from ocrd import Processor
 
@@ -168,19 +164,9 @@ class ExtractPages(Processor):
             num_page_id = int(page_id.strip(page_id.strip("0123456789")))
             LOG.info("INPUT FILE %i / %s", n, page_id)
             pcgts = page_from_file(self.workspace.download_file(input_file))
+            self.add_metadata(pcgts)
             page = pcgts.get_Page()
             ptype = page.get_type()
-            metadata = pcgts.get_Metadata() # ensured by from_file()
-            metadata.add_MetadataItem(
-                MetadataItemType(type_="processingStep",
-                                 name=self.ocrd_tool['steps'][0],
-                                 value=TOOL,
-                                 Labels=[LabelsType(
-                                     externalModel="ocrd-tool",
-                                     externalId="parameters",
-                                     Label=[LabelType(type_=name,
-                                                      value=self.parameter[name])
-                                            for name in self.parameter])]))
             page_image, page_coords, page_image_info = self.workspace.image_from_page(
                 page, page_id,
                 feature_filter='binarized',

--- a/ocrd_segment/extract_regions.py
+++ b/ocrd_segment/extract_regions.py
@@ -10,10 +10,6 @@ from ocrd_utils import (
     polygon_from_points,
     MIME_TO_EXT
 )
-from ocrd_models.ocrd_page import (
-    LabelsType, LabelType,
-    MetadataItemType
-)
 from ocrd_modelfactory import page_from_file
 from ocrd import Processor
 
@@ -72,18 +68,8 @@ class ExtractRegions(Processor):
             page_id = input_file.pageId or input_file.ID
             LOG.info("INPUT FILE %i / %s", n, page_id)
             pcgts = page_from_file(self.workspace.download_file(input_file))
+            self.add_metadata(pcgts)
             page = pcgts.get_Page()
-            metadata = pcgts.get_Metadata() # ensured by from_file()
-            metadata.add_MetadataItem(
-                MetadataItemType(type_="processingStep",
-                                 name=self.ocrd_tool['steps'][0],
-                                 value=TOOL,
-                                 Labels=[LabelsType(
-                                     externalModel="ocrd-tool",
-                                     externalId="parameters",
-                                     Label=[LabelType(type_=name,
-                                                      value=self.parameter[name])
-                                            for name in self.parameter])]))
             page_image, page_coords, page_image_info = self.workspace.image_from_page(
                 page, page_id,
                 transparency=self.parameter['transparency'])

--- a/ocrd_segment/import_coco_segmentation.py
+++ b/ocrd_segment/import_coco_segmentation.py
@@ -17,8 +17,6 @@ from ocrd_modelfactory import page_from_file
 # pragma pylint: disable=unused-import
 # (region types will be referenced indirectly via globals())
 from ocrd_models.ocrd_page import (
-    MetadataItemType,
-    LabelsType, LabelType,
     CoordsType,
     TextRegionType,
     ImageRegionType,
@@ -138,20 +136,8 @@ class ImportCOCOSegmentation(Processor):
             num_page_id = int(page_id.strip(page_id.strip("0123456789")))
             LOG.info("INPUT FILE %i / %s", n, page_id)
             pcgts = page_from_file(self.workspace.download_file(input_file))
+            self.add_metadata(pcgts)
             page = pcgts.get_Page()
-
-            # add metadata about this operation and its runtime parameters:
-            metadata = pcgts.get_Metadata() # ensured by from_file()
-            metadata.add_MetadataItem(
-                MetadataItemType(type_="processingStep",
-                                 name=self.ocrd_tool['steps'][0],
-                                 value=TOOL,
-                                 Labels=[LabelsType(
-                                     externalModel="ocrd-tool",
-                                     externalId="parameters",
-                                     Label=[LabelType(type_=name,
-                                                      value=self.parameter[name])
-                                            for name in self.parameter.keys()])]))
 
             # find COCO image
             if page.imageFilename in images_by_filename:

--- a/ocrd_segment/import_image_segmentation.py
+++ b/ocrd_segment/import_image_segmentation.py
@@ -18,8 +18,6 @@ from ocrd_modelfactory import page_from_file
 # pragma pylint: disable=unused-import
 # (region types will be referenced indirectly via globals())
 from ocrd_models.ocrd_page import (
-    MetadataItemType,
-    LabelsType, LabelType,
     CoordsType,
     TextRegionType,
     ImageRegionType,
@@ -89,20 +87,8 @@ class ImportImageSegmentation(Processor):
             input_file, segmentation_file = ift
             LOG.info("processing page %s", input_file.pageId)
             pcgts = page_from_file(self.workspace.download_file(input_file))
+            self.add_metadata(pcgts)
             page = pcgts.get_Page()
-
-            # add metadata about this operation and its runtime parameters:
-            metadata = pcgts.get_Metadata() # ensured by from_file()
-            metadata.add_MetadataItem(
-                MetadataItemType(type_="processingStep",
-                                 name=self.ocrd_tool['steps'][0],
-                                 value=TOOL,
-                                 Labels=[LabelsType(
-                                     externalModel="ocrd-tool",
-                                     externalId="parameters",
-                                     Label=[LabelType(type_=name,
-                                                      value=self.parameter[name])
-                                            for name in self.parameter.keys()])]))
 
             # import mask image
             segmentation_filename = self.workspace.download_file(segmentation_file).local_filename

--- a/ocrd_segment/ocrd-tool.json
+++ b/ocrd_segment/ocrd-tool.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "git_url": "https://github.com/OCR-D/ocrd_segment",
   "tools": {
     "ocrd-segment-repair": {

--- a/ocrd_segment/repair.py
+++ b/ocrd_segment/repair.py
@@ -172,7 +172,7 @@ class RepairSegmentation(Processor):
                 content=to_xml(pcgts))
     
     def sanitize_page(self, page, page_id):
-        regions = page.get_TextRegion()
+        regions = page.get_AllRegions(classes=['text'])
         page_image, page_coords, _ = self.workspace.image_from_page(
             page, page_id)
         for region in regions:

--- a/ocrd_segment/repair.py
+++ b/ocrd_segment/repair.py
@@ -240,11 +240,16 @@ class RepairSegmentation(Processor):
                     LOG.warning('Ignoring contour %d too small (%d/%d) in region "%s"',
                                 i, area, total_area, region.id)
                     continue
-                # simplify shape:
+                # simplify shape (until valid):
                 # can produce invalid (self-intersecting) polygons:
                 #polygon = cv2.approxPolyDP(contour, 2, False)[:, 0, ::] # already ordered x,y
                 polygon = contour[:, 0, ::] # already ordered x,y
-                polygon = Polygon(polygon).simplify(1).exterior.coords
+                polygon = Polygon(polygon)
+                for tolerance in range(2, int(polygon.area)):
+                    polygon = polygon.simplify(tolerance)
+                    if polygon.is_valid:
+                        break
+                polygon = polygon.exterior.coords[:-1] # keep open
                 if len(polygon) < 4:
                     LOG.warning('Ignoring contour %d less than 4 points in region "%s"',
                                 i, region.id)

--- a/ocrd_segment/repair.py
+++ b/ocrd_segment/repair.py
@@ -6,7 +6,7 @@ from skimage import draw
 from scipy.ndimage import filters, morphology
 import cv2
 import numpy as np
-from shapely.geometry import Polygon, LineString
+from shapely.geometry import asPolygon, Polygon, LineString
 
 from ocrd import Processor
 from ocrd_utils import (
@@ -361,6 +361,8 @@ def _plausibilize_group(regionspolys, rogroup, mark_for_deletion, mark_for_mergi
                 superpoly = superpoly.union(poly)
                 if superpoly.type == 'MultiPolygon':
                     superpoly = superpoly.convex_hull
+                if superpoly.minimum_clearance < 1.0:
+                    superpoly = asPolygon(np.round(superpoly.exterior.coords))
                 for tolerance in range(1, int(superpoly.area)):
                     if superpoly.is_valid:
                         break

--- a/ocrd_segment/repair.py
+++ b/ocrd_segment/repair.py
@@ -359,7 +359,10 @@ def _plausibilize_group(regionspolys, rogroup, mark_for_deletion, mark_for_mergi
                 # and use-cases in the future
                 superpoly = Polygon(polygon_from_points(superreg.get_Coords().points))
                 superpoly = superpoly.union(poly)
-                superreg.get_Coords().points = points_from_polygon(superpoly.exterior.coords)
+                if superpoly.type == 'MultiPolygon':
+                    superpoly = superpoly.convex_hull
+                superpoly = superpoly.exterior.coords[:-1] # keep open
+                superreg.get_Coords().points = points_from_polygon(superpoly)
                 # FIXME should we merge/mix attributes and features?
                 if region.get_orientation() != superreg.get_orientation():
                     LOG.warning('Merging region "%s" with orientation %f into "%s" with %f',

--- a/ocrd_segment/repair.py
+++ b/ocrd_segment/repair.py
@@ -245,7 +245,7 @@ class RepairSegmentation(Processor):
                 #polygon = cv2.approxPolyDP(contour, 2, False)[:, 0, ::] # already ordered x,y
                 polygon = contour[:, 0, ::] # already ordered x,y
                 polygon = Polygon(polygon)
-                for tolerance in range(2, int(polygon.area)):
+                for tolerance in range(1, int(polygon.area)):
                     polygon = polygon.simplify(tolerance)
                     if polygon.is_valid:
                         break
@@ -361,6 +361,10 @@ def _plausibilize_group(regionspolys, rogroup, mark_for_deletion, mark_for_mergi
                 superpoly = superpoly.union(poly)
                 if superpoly.type == 'MultiPolygon':
                     superpoly = superpoly.convex_hull
+                for tolerance in range(1, int(superpoly.area)):
+                    if superpoly.is_valid:
+                        break
+                    superpoly = superpoly.simplify(tolerance)
                 superpoly = superpoly.exterior.coords[:-1] # keep open
                 superreg.get_Coords().points = points_from_polygon(superpoly)
                 # FIXME should we merge/mix attributes and features?

--- a/ocrd_segment/repair.py
+++ b/ocrd_segment/repair.py
@@ -78,13 +78,8 @@ class RepairSegmentation(Processor):
                                             check_baseline=False)
             if not report.is_valid:
                 LOG.warning(report.to_xml())
+                # TODO: maybe skip this page if report contains any CoordinateValidityError
 
-            #
-            # sanitize region segmentation (shrink to hull of lines)
-            #
-            if sanitize:
-                self.sanitize_page(page, page_id)
-                
             #
             # plausibilize region segmentation (remove redundant text regions)
             #
@@ -161,6 +156,12 @@ class RepairSegmentation(Processor):
                     # pass the regions sorted (see above)
                     _plausibilize_group(regionspolys, rogroup, mark_for_deletion, mark_for_merging)
 
+            #
+            # sanitize region segmentation (shrink to hull of lines)
+            #
+            if sanitize:
+                self.sanitize_page(page, page_id)
+                
             file_id = make_file_id(input_file, self.output_file_grp)
             self.workspace.add_file(
                 ID=file_id,

--- a/ocrd_segment/replace_original.py
+++ b/ocrd_segment/replace_original.py
@@ -11,8 +11,6 @@ from ocrd_utils import (
     MIMETYPE_PAGE
 )
 from ocrd_models.ocrd_page import (
-    LabelsType, LabelType,
-    MetadataItemType,
     TextRegionType,
     to_xml
 )
@@ -57,18 +55,8 @@ class ReplaceOriginal(Processor):
             page_id = input_file.pageId or input_file.ID
             LOG.info("INPUT FILE %i / %s", n, page_id)
             pcgts = page_from_file(self.workspace.download_file(input_file))
+            self.add_metadata(pcgts)
             page = pcgts.get_Page()
-            metadata = pcgts.get_Metadata() # ensured by from_file()
-            metadata.add_MetadataItem(
-                MetadataItemType(type_="processingStep",
-                                 name=self.ocrd_tool['steps'][0],
-                                 value=TOOL,
-                                 Labels=[LabelsType(
-                                     externalModel="ocrd-tool",
-                                     externalId="parameters",
-                                     Label=[LabelType(type_=name,
-                                                      value=self.parameter[name])
-                                            for name in self.parameter])]))
             page_image, page_coords, page_image_info = self.workspace.image_from_page(
                 page, page_id,
                 feature_filter=feature_filter,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ocrd >= 2.13.1
+ocrd >= 2.16.2
 shapely >= 1.7.1
 scikit-image
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ocrd >= 2.13.1
-shapely
+shapely >= 1.7.1
 scikit-image
 numpy


### PR DESCRIPTION
This attempts to fix problems caused by invalid polygons from `ocrd-segment-repair` (both in `sanitize` and `plausibilize` mode).

This taught me another lesson about what can go wrong with Shapely / numpy / PAGE interaction. To sum up:

1. Ensuring valid polygons on the input side (e.g. from OpenCV) is always necessary. The only generic way I can think of is to feed them through `simplify` with ever increasing tolerance until valid. **EDIT2** The problem is that the result of the algorithm implemented in Shapely/GEOS depends on the starting point it picked. In pathological cases, _no simplification whatsoever_ can be achieved. (The only thing that then helps is re-ordering...)
2. Operations like `union` or `intersection` can create collections of shapes. **EDIT** There are actually 2 cases here:
   1. homogeneous ([MultiPolygon](https://shapely.readthedocs.io/en/stable/manual.html#MultiPolygon)) – a discontiguous collection of Polygon – in which case one needs the convex hull.
   2. heterogeneous ([GeometryCollection](https://shapely.readthedocs.io/en/stable/manual.html#collections)) – a collection of Polygon with Point or LineString – in which case one needs to filter out those shapes which have no intrinsic area (and then check again for the other cases)
3. Operations like `union` or `intersection` can create non-integer points, which when rounded for PAGE serialization can become invalid paths. Unfortunately, Shapely _always_ calculates in floating point internally. So all we can do is rounding and then ensuring validity (as in 1).

Related:
- https://github.com/cisocrgroup/ocrd_cis/issues/67
- https://github.com/cisocrgroup/ocrd_cis/issues/62
- https://github.com/OCR-D/ocrd_tesserocr/issues/149
- https://github.com/OCR-D/ocrd_tesserocr/issues/151