### PR TITLE
Update Dockerfile to core 2.67.1 and fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/ocrd/core:v2.67.1 AS base
+FROM docker.io/ocrd/core:v2.67.2 AS base
 ARG VCS_REF
 ARG BUILD_DATE
 LABEL \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocrd/core:v2.67.1 AS base
+FROM docker.io/ocrd/core:v2.67.1 AS base
 ARG VCS_REF
 ARG BUILD_DATE
 LABEL \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocrd/core:v2.62.0 AS base
+FROM ocrd/core:v2.67.1 AS base
 ARG VCS_REF
 ARG BUILD_DATE
 LABEL \
@@ -7,14 +7,14 @@ LABEL \
     org.label-schema.vcs-url="https://github.com/OCR-D/ocrd_segment" \
     org.label-schema.build-date=$BUILD_DATE
 
-WORKDIR /build
+WORKDIR /build/ocrd_segment
 COPY setup.py .
 COPY ocrd_segment/ocrd-tool.json .
 COPY ocrd_segment ./ocrd_segment
 COPY requirements.txt .
 COPY README.md .
 RUN pip install .
-RUN rm -rf /build
+RUN rm -rf /build/ocrd_segment
 
 WORKDIR /data
 VOLUME ["/data"]


### PR DESCRIPTION
Update version of ocrd-core base image to latest core version. Fix work/build-dir usage and removal. Build dir in core was changed to /build/core.
~~Clarification still needed if [proposed change for ocrd_tesserocr](https://github.com/OCR-D/ocrd_tesserocr/pull/218#discussion_r1693159828) also applies here.~~