### PR TITLE
Fix logger call in repair.py

### DIFF
--- a/ocrd_segment/repair.py
+++ b/ocrd_segment/repair.py
@@ -273,7 +273,7 @@ class RepairSegmentation(Processor):
                                    marked_for_deletion,
                                    marked_for_merging,
                                    marked_for_splitting,
-                                   log)
+                                   self.logger)
 
     def spread_segments(self, page, page_id):
         level = self.parameter['spread_level']


### PR DESCRIPTION
A fix for the following error. I have not retested locally.

```shell
Caused by:
  Process `ocrd_segment_repair_5 (3)` terminated with an error exit status (1)


Command executed:

  apptainer exec --bind /local/u12198_8249264/1f5591b3-5814-4daa-93c6-bf3cabc946ba/427a121d-6d60-4d81-9bd6-86340d4dd22c:/ws_data --bind /local/u12198_8249264/ocrd_models/ocrd-resources:/usr/local/share/ocrd-resources --env OCRD_METS_CACHING=true /local/u12198_8249264/ocrd_processor_sifs/ocrd_segment.sif ocrd-segment-repair -U /ws_data/mets_server.sock -w /ws_data -m /ws_data/mets.xml --page-id PHYS_0007 -I OCR-D-SEG-BLOCK-TESSERACT -O OCR-D-SEGMENT-REPAIR -p '{"plausibilize": true, "plausibilize_merge_min_overlap": 0.7}'

Command exit status:
  1

Command output:
  (empty)

Command error:
  /usr/local/lib/python3.8/site-packages/ocrd_segment/repair.py:327: ShapelyDeprecationWarning: The 'almost_equals()' method is deprecated and will be removed in Shapely 2.1; use 'equals_exact()' instead
    if poly1.almost_equals(poly2):
  13:32:03.203 ERROR ocrd.processor.base - Failure on page PHYS_0007: name 'log' is not defined
  Traceback (most recent call last):
    File "/build/core/build/__editable__.ocrd-3.4.0-py3-none-any/ocrd/processor/base.py", line 710, in process_workspace_handle_page_task
      task.result()
    File "/build/core/build/__editable__.ocrd-3.4.0-py3-none-any/ocrd/processor/base.py", line 124, in result
      return self.fn(*self.args, **self.kwargs)
    File "/build/core/build/__editable__.ocrd-3.4.0-py3-none-any/ocrd/processor/base.py", line 1157, in _page_worker
      _page_worker_processor.process_page_file(*input_files)
    File "/build/core/build/__editable__.ocrd-3.4.0-py3-none-any/ocrd/processor/base.py", line 809, in process_page_file
      result = self.process_page_pcgts(*input_pcgts, page_id=page_id)
    File "/usr/local/lib/python3.8/site-packages/ocrd_segment/repair.py", line 183, in process_page_pcgts
      self.plausibilize_page(page, page_id)
    File "/usr/local/lib/python3.8/site-packages/ocrd_segment/repair.py", line 276, in plausibilize_page
      log)
  NameError: name 'log' is not defined
```